### PR TITLE
Update default targets in template file

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -18,7 +18,6 @@ defmodule Mix.Tasks.Nerves.New do
     "rpi2",
     "rpi3",
     "bbb",
-    "linkit",
     "ev3",
     "qemu_arm"
   ]

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -19,7 +19,8 @@ defmodule Mix.Tasks.Nerves.New do
     "rpi3",
     "bbb",
     "ev3",
-    "qemu_arm"
+    "qemu_arm",
+    "x86_64"
   ]
 
   @new [


### PR DESCRIPTION
This PR removes linkit and adds x86_64 to the official list.