### PR TITLE
Alias Deps.Get

### DIFF
--- a/lib/mix/tasks/nerves/deps.get.ex
+++ b/lib/mix/tasks/nerves/deps.get.ex
@@ -1,0 +1,18 @@
+defmodule Mix.Tasks.Nerves.Deps.Get do
+  use Mix.Task
+
+  import Mix.Nerves.IO
+  
+  def run(_argv) do
+    debug_info("Nerves.Deps.Get Start")
+
+    # We want to start Nerves.Env so it compiles `nerves`
+    # but pass --disable to prevent it from compiling
+    # the system and toolchain during this time.
+    Mix.Tasks.Nerves.Env.run(["--disable"])
+    Mix.Task.run("nerves.artifact.get", [])
+    Nerves.Bootstrap.check_for_update()
+
+    debug_info("Nerves.Deps.Get End")
+  end
+end

--- a/lib/mix/tasks/nerves/loadpaths.ex
+++ b/lib/mix/tasks/nerves/loadpaths.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
   def run(_args) do
     unless System.get_env("NERVES_PRECOMPILE") == "1" do
       debug_info("Loadpaths Start")
-
+      
       case Code.ensure_compiled?(Nerves.Env) do
         true ->
           try do

--- a/lib/mix/tasks/nerves/precompile.ex
+++ b/lib/mix/tasks/nerves/precompile.ex
@@ -47,11 +47,12 @@ defmodule Mix.Tasks.Nerves.Precompile do
         Please update your mix.exs target aliases to:
         
         defp aliases(_target) do
-          Nerves.Bootstrap.merge_aliases([
-            # You can add your own custom mix aliases here
-          ])
+          [
+            # Add custom mix aliases here
+          ]
+          |> Nerves.Bootstrap.add_aliases()
         end
-        
+
       """,
       IO.ANSI.reset()])
     end

--- a/lib/mix/tasks/nerves/precompile.ex
+++ b/lib/mix/tasks/nerves/precompile.ex
@@ -46,7 +46,11 @@ defmodule Mix.Tasks.Nerves.Precompile do
       Mix.raise("""
       
         Nerves is missing an alias for \"deps.get\"
-        Please update your mix.exs target aliases to:
+        Please update nerves to the latest version:
+
+        mix deps.update nerves
+        
+        Also update your mix.exs target aliases to:
         
         defp aliases(_target) do
           [
@@ -55,9 +59,6 @@ defmodule Mix.Tasks.Nerves.Precompile do
           |> Nerves.Bootstrap.add_aliases()
         end
 
-        and update nerves to the latest version:
-
-        mix deps.update nerves
       """)
     end
   end

--- a/lib/mix/tasks/nerves/precompile.ex
+++ b/lib/mix/tasks/nerves/precompile.ex
@@ -12,7 +12,10 @@ defmodule Mix.Tasks.Nerves.Precompile do
     # nerves_bootstrap.
     unless System.get_env("NERVES_ENV_DISABLED") do
       System.put_env("NERVES_PRECOMPILE", "1")
-      check_aliases()
+      
+      Mix.Project.config()[:aliases]
+      |> check_aliases()
+      
       Mix.Tasks.Nerves.Env.run([])
       parent = Mix.Project.config()[:app]
       system_app = Nerves.Env.system().app
@@ -37,13 +40,12 @@ defmodule Mix.Tasks.Nerves.Precompile do
     debug_info("Precompile End")
   end
 
-  def check_aliases() do
-    aliases = Mix.Project.config()[:aliases]
+  def check_aliases(aliases) do
     deps_get = Keyword.get(aliases, String.to_atom("deps.get"), [])
     unless Enum.member?(deps_get, "nerves.deps.get") do
-      Mix.shell.info([IO.ANSI.yellow(),"""
+      Mix.raise("""
       
-      ** Warning ** Nerves is missing an alias for \"deps.get\"
+        Nerves is missing an alias for \"deps.get\"
         Please update your mix.exs target aliases to:
         
         defp aliases(_target) do
@@ -53,8 +55,10 @@ defmodule Mix.Tasks.Nerves.Precompile do
           |> Nerves.Bootstrap.add_aliases()
         end
 
-      """,
-      IO.ANSI.reset()])
+        and update nerves to the latest version:
+
+        mix deps.update nerves
+      """)
     end
   end
 

--- a/lib/mix/tasks/nerves/precompile.ex
+++ b/lib/mix/tasks/nerves/precompile.ex
@@ -12,6 +12,7 @@ defmodule Mix.Tasks.Nerves.Precompile do
     # nerves_bootstrap.
     unless System.get_env("NERVES_ENV_DISABLED") do
       System.put_env("NERVES_PRECOMPILE", "1")
+      check_aliases()
       Mix.Tasks.Nerves.Env.run([])
       parent = Mix.Project.config()[:app]
       system_app = Nerves.Env.system().app
@@ -35,4 +36,25 @@ defmodule Mix.Tasks.Nerves.Precompile do
 
     debug_info("Precompile End")
   end
+
+  def check_aliases() do
+    aliases = Mix.Project.config()[:aliases]
+    deps_get = Keyword.get(aliases, String.to_atom("deps.get"), [])
+    unless Enum.member?(deps_get, "nerves.deps.get") do
+      Mix.shell.info([IO.ANSI.yellow(),"""
+      
+      ** Warning ** Nerves is missing an alias for \"deps.get\"
+        Please update your mix.exs target aliases to:
+        
+        defp aliases(_target) do
+          Nerves.Bootstrap.merge_aliases([
+            # You can add your own custom mix aliases here
+          ])
+        end
+        
+      """,
+      IO.ANSI.reset()])
+    end
+  end
+
 end

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -50,19 +50,15 @@ defmodule Nerves.Bootstrap do
   
   defp append(aliases, a, na) do
     key = String.to_atom(a)
-    unless Enum.member?(aliases, key) do
-      Keyword.update(aliases, key, [a, na], &(&1 ++ [na]))
-    else
-      aliases
-    end
+    Keyword.update(aliases, key, [a, na], &(drop(&1, na) ++ [na]))
   end
   
   defp prepend(aliases, a, na) do
     key = String.to_atom(a)
-    unless Enum.member?(aliases, key) do
-      Keyword.update(aliases, key, [na, a], &([na | &1]))
-    else
-      aliases
-    end
+    Keyword.update(aliases, key, [na, a], &([na | drop(&1, na)]))
+  end
+
+  defp drop(aliases, a) do
+    Enum.reject(aliases, &(&1 === a))
   end
 end

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -1,7 +1,14 @@
 defmodule Nerves.Bootstrap do
   @version Mix.Project.config()[:version]
+  
+  @doc """
+  Returns the version of nerves_bootstrap
+  """
   def version, do: @version
 
+  @doc """
+  Check the nerves_bootstrap updates from hex
+  """
   def check_for_update() do
     try do
       Hex.start()
@@ -28,6 +35,34 @@ defmodule Nerves.Bootstrap do
       end
     rescue
       _e -> :noop 
+    end
+  end
+
+  @doc """
+  Add the required Nerves bootstrap aliases to the existing ones
+  """
+  def add_aliases(aliases) do
+    aliases
+    |> append("deps.get", "nerves.deps.get")
+    |> prepend("deps.precompile", "nerves.precompile")
+    |> append("deps.loadpaths", "nerves.loadpaths")
+  end
+  
+  defp append(aliases, a, na) do
+    key = String.to_atom(a)
+    unless Enum.member?(aliases, key) do
+      Keyword.update(aliases, key, [a, na], &(&1 ++ [na]))
+    else
+      aliases
+    end
+  end
+  
+  defp prepend(aliases, a, na) do
+    key = String.to_atom(a)
+    unless Enum.member?(aliases, key) do
+      Keyword.update(aliases, key, [na, a], &([na | &1]))
+    else
+      aliases
     end
   end
 end

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -73,8 +73,9 @@ defmodule <%= app_module %>.MixProject do
   defp aliases("host"), do: []
 
   defp aliases(_target) do
-    Nerves.Bootstrap.merge_aliases([
-      # You can add your own custom mix aliases here
-    ])
+    [
+      # Add custom mix aliases here
+    ]
+    |> Nerves.Bootstrap.add_aliases()
   end
 end

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -73,10 +73,8 @@ defmodule <%= app_module %>.MixProject do
   defp aliases("host"), do: []
 
   defp aliases(_target) do
-    [
-      "deps.precompile": ["nerves.precompile", "deps.precompile"],
-      "deps.loadpaths": ["deps.loadpaths", "nerves.loadpaths"],
-      "deps.get": ["deps.get", "nerves.deps.get"]
-    ]
+    Nerves.Bootstrap.merge_aliases([
+      # You can add your own custom mix aliases here
+    ])
   end
 end

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -75,7 +75,8 @@ defmodule <%= app_module %>.MixProject do
   defp aliases(_target) do
     [
       "deps.precompile": ["nerves.precompile", "deps.precompile"],
-      "deps.loadpaths": ["deps.loadpaths", "nerves.loadpaths"]
+      "deps.loadpaths": ["deps.loadpaths", "nerves.loadpaths"],
+      "deps.get": ["deps.get", "nerves.deps.get"]
     ]
   end
 end

--- a/test/nerves_bootstrap_test.exs
+++ b/test/nerves_bootstrap_test.exs
@@ -26,4 +26,20 @@ defmodule Nerves.BootstrapTest do
     assert Keyword.get(aliases, :"deps.get") == ["deps.get", "custom", "nerves.deps.get"]
     assert Keyword.get(aliases, :"custom") == ["custom"]
   end
+
+  test "aliases are dropped if they already exist" do
+    deps_precompile = ["nerves.precompile", "deps.precompile"]
+    deps_loadpaths = ["deps.loadpaths", "nerves.loadpaths"]
+    deps_get = ["deps.get", "nerves.deps.get"]
+ 
+    nerves_aliases = [
+      "deps.precompile": deps_precompile,
+      "deps.loadpaths": deps_loadpaths
+    ]
+
+    aliases = Nerves.Bootstrap.add_aliases(nerves_aliases)
+    assert Keyword.get(aliases, :"deps.precompile") == deps_precompile
+    assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
+    assert Keyword.get(aliases, :"deps.get") == deps_get
+  end
 end

--- a/test/nerves_bootstrap_test.exs
+++ b/test/nerves_bootstrap_test.exs
@@ -1,0 +1,29 @@
+defmodule Nerves.BootstrapTest do
+  use ExUnit.Case
+
+  test "aliases are injected properly" do
+    deps_precompile = ["nerves.precompile", "deps.precompile"]
+    deps_loadpaths = ["deps.loadpaths", "nerves.loadpaths"]
+    deps_get = ["deps.get", "nerves.deps.get"]
+ 
+    aliases = Nerves.Bootstrap.add_aliases([])
+    assert Keyword.get(aliases, :"deps.precompile") == deps_precompile
+    assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
+    assert Keyword.get(aliases, :"deps.get") == deps_get
+  end
+
+  test "custom aliases are maintained" do
+    custom_aliases = [
+      "deps.precompile": ["custom", "deps.precompile"],
+      "deps.loadpaths": ["custom", "deps.loadpaths"],
+      "deps.get": ["deps.get", "custom"],
+      "custom": ["custom"]
+    ]
+    aliases = Nerves.Bootstrap.add_aliases(custom_aliases)
+
+    assert Keyword.get(aliases, :"deps.precompile") == ["nerves.precompile", "custom", "deps.precompile"]
+    assert Keyword.get(aliases, :"deps.loadpaths") == ["custom", "deps.loadpaths", "nerves.loadpaths"]
+    assert Keyword.get(aliases, :"deps.get") == ["deps.get", "custom", "nerves.deps.get"]
+    assert Keyword.get(aliases, :"custom") == ["custom"]
+  end
+end

--- a/test/nerves_bootstrap_test.exs
+++ b/test/nerves_bootstrap_test.exs
@@ -42,4 +42,18 @@ defmodule Nerves.BootstrapTest do
     assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
     assert Keyword.get(aliases, :"deps.get") == deps_get
   end
+
+  test "raise if deps.get alias is missing" do
+    deps_precompile = ["nerves.precompile", "deps.precompile"]
+    deps_loadpaths = ["deps.loadpaths", "nerves.loadpaths"]
+ 
+    nerves_aliases = [
+      "deps.precompile": deps_precompile,
+      "deps.loadpaths": deps_loadpaths
+    ]
+
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Nerves.Precompile.check_aliases(nerves_aliases)
+    end
+  end
 end

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -1,6 +1,6 @@
 Code.require_file("mix_helper.exs", __DIR__)
 
-defmodule Nerves.BootstrapTest do
+defmodule Nerves.NewTest do
   use ExUnit.Case
   import MixHelper
 


### PR DESCRIPTION
WIP

This PR goes along with changes being published to the `refactor-provider` branch in https://github.com/nerves-project/nerves

This PR does the following
* Create a new mix task `nerves.deps.get`
* Update the new project generator to alias this new task on `deps.get`
* Starts `Nerves.Env` and calls `nerves.artifact.get` to fetch all artifact archives from urls if provided in nerves_package config.
* Checks for `nerves_bootstrap` update 
  