### PR TITLE
Rebar override scripts being evaluated too early

### DIFF
--- a/lib/mix/tasks/nerves/precompile.ex
+++ b/lib/mix/tasks/nerves/precompile.ex
@@ -32,9 +32,10 @@ defmodule Mix.Tasks.Nerves.Precompile do
       apply(m, f, a)
       Mix.Task.reenable("deps.compile")
       Mix.Task.reenable("compile")
+      
       System.put_env("NERVES_PRECOMPILE", "0")
-
-      Mix.Tasks.Nerves.Loadpaths.run([])
+      
+      Mix.Task.rerun("nerves.loadpaths")
     end
 
     debug_info("Precompile End")

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -44,8 +44,7 @@ defmodule Nerves.Bootstrap do
   def add_aliases(aliases) do
     aliases
     |> append("deps.get", "nerves.deps.get")
-    |> prepend("deps.precompile", "nerves.precompile")
-    |> append("deps.loadpaths", "nerves.loadpaths")
+    |> prepend("deps.loadpaths", "nerves.loadpaths")
   end
   
   defp append(aliases, a, na) do

--- a/test/nerves_bootstrap_test.exs
+++ b/test/nerves_bootstrap_test.exs
@@ -2,53 +2,44 @@ defmodule Nerves.BootstrapTest do
   use ExUnit.Case
 
   test "aliases are injected properly" do
-    deps_precompile = ["nerves.precompile", "deps.precompile"]
-    deps_loadpaths = ["deps.loadpaths", "nerves.loadpaths"]
+    deps_loadpaths = ["nerves.loadpaths", "deps.loadpaths"]
     deps_get = ["deps.get", "nerves.deps.get"]
  
     aliases = Nerves.Bootstrap.add_aliases([])
-    assert Keyword.get(aliases, :"deps.precompile") == deps_precompile
     assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
     assert Keyword.get(aliases, :"deps.get") == deps_get
   end
 
   test "custom aliases are maintained" do
     custom_aliases = [
-      "deps.precompile": ["custom", "deps.precompile"],
       "deps.loadpaths": ["custom", "deps.loadpaths"],
       "deps.get": ["deps.get", "custom"],
       "custom": ["custom"]
     ]
     aliases = Nerves.Bootstrap.add_aliases(custom_aliases)
 
-    assert Keyword.get(aliases, :"deps.precompile") == ["nerves.precompile", "custom", "deps.precompile"]
-    assert Keyword.get(aliases, :"deps.loadpaths") == ["custom", "deps.loadpaths", "nerves.loadpaths"]
+    assert Keyword.get(aliases, :"deps.loadpaths") == ["nerves.loadpaths", "custom", "deps.loadpaths"]
     assert Keyword.get(aliases, :"deps.get") == ["deps.get", "custom", "nerves.deps.get"]
     assert Keyword.get(aliases, :"custom") == ["custom"]
   end
 
   test "aliases are dropped if they already exist" do
-    deps_precompile = ["nerves.precompile", "deps.precompile"]
-    deps_loadpaths = ["deps.loadpaths", "nerves.loadpaths"]
+    deps_loadpaths = ["nerves.loadpaths", "deps.loadpaths"]
     deps_get = ["deps.get", "nerves.deps.get"]
  
     nerves_aliases = [
-      "deps.precompile": deps_precompile,
       "deps.loadpaths": deps_loadpaths
     ]
 
     aliases = Nerves.Bootstrap.add_aliases(nerves_aliases)
-    assert Keyword.get(aliases, :"deps.precompile") == deps_precompile
     assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
     assert Keyword.get(aliases, :"deps.get") == deps_get
   end
 
   test "raise if deps.get alias is missing" do
-    deps_precompile = ["nerves.precompile", "deps.precompile"]
-    deps_loadpaths = ["deps.loadpaths", "nerves.loadpaths"]
- 
+    deps_loadpaths = ["nerves.loadpaths", "deps.loadpaths"]
+    
     nerves_aliases = [
-      "deps.precompile": deps_precompile,
       "deps.loadpaths": deps_loadpaths
     ]
 


### PR DESCRIPTION
Fixes an issue with projects that contain rebar based dependencies with `rebar.config.script` overrides being evaluated and cached too early in the Mix lifecycle.

The issue was originally identified here
https://github.com/saleyn/erlexec/issues/102#issuecomment-320464641

This issue is only appearing when trying to cross compile under nerves env where the cross compiler is not being invoked when rebar compiles. This is due to the call order of starting the Nerves env. This PR alters the call order and forces all dependency Mix files to reevaluate once the Nerves env has finished bootstrap.

The docs in `Nerves` about internal structure will need to be updated.