### PR TITLE
Remove function call to archive from mixfile

### DIFF
--- a/lib/mix/tasks/nerves/deps.get.ex
+++ b/lib/mix/tasks/nerves/deps.get.ex
@@ -2,9 +2,13 @@ defmodule Mix.Tasks.Nerves.Deps.Get do
   use Mix.Task
 
   import Mix.Nerves.IO
-  
-  def run(_argv) do
+
+  def run(args) do
     debug_info("Nerves.Deps.Get Start")
+
+    unless "--skip-deps-get" in args do
+      Mix.Task.run("deps.get", args)
+    end
 
     # We want to start Nerves.Env so it compiles `nerves`
     # but pass --disable to prevent it from compiling

--- a/lib/mix/tasks/nerves/deps.update.ex
+++ b/lib/mix/tasks/nerves/deps.update.ex
@@ -1,0 +1,14 @@
+defmodule Mix.Tasks.Nerves.Deps.Update do
+  use Mix.Task
+
+  import Mix.Nerves.IO
+
+  def run(args) do
+    debug_info("Nerves.Deps.Update Start")
+
+    Mix.Task.run("deps.update", args)
+    Mix.Task.run("nerves.deps.get", ["--skip-deps-get" | args])
+
+    debug_info("Nerves.Deps.Update End")
+  end
+end

--- a/lib/mix/tasks/nerves/loadpaths.ex
+++ b/lib/mix/tasks/nerves/loadpaths.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
   use Mix.Task
   import Mix.Nerves.IO
 
-  def run(_args) do
+  def run(args) do
     unless System.get_env("NERVES_PRECOMPILE") == "1" do
       debug_info("Loadpaths Start")
       
@@ -22,6 +22,8 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
       end
       debug_info("Loadpaths End")
     end
+
+    Mix.Task.run("deps.loadpaths", args)
   end
 
   def env(k) do

--- a/lib/mix/tasks/nerves/precompile.ex
+++ b/lib/mix/tasks/nerves/precompile.ex
@@ -55,9 +55,10 @@ defmodule Mix.Tasks.Nerves.Precompile do
         
         defp aliases(_target) do
           [
-            # Add custom mix aliases here
+            "deps.get": "nerves.deps.get",
+            "deps.loadpaths": "nerves.loadpaths",
+            "deps.update": "nerves.deps.update"
           ]
-          |> Nerves.Bootstrap.add_aliases()
         end
 
       """)

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -74,8 +74,9 @@ defmodule <%= app_module %>.MixProject do
 
   defp aliases(_target) do
     [
-      # Add custom mix aliases here
+      "deps.get": "nerves.deps.get",
+      "deps.loadpaths": "nerves.loadpaths",
+      "deps.update": "nerves.deps.update"
     ]
-    |> Nerves.Bootstrap.add_aliases()
   end
 end


### PR DESCRIPTION
When the archive is not available, mix will break including the tasks archive.check and archive.install.

By moving the recursive task call into the nerves tasks it gives nerves full control of the order tasks will be run instead of asking users to update their mixfiles. In theory users should only have to update their mixfile if new aliases are added.