### PR TITLE
Add loadconfig mix task

### DIFF
--- a/lib/mix/tasks/nerves/loadconfig.ex
+++ b/lib/mix/tasks/nerves/loadconfig.ex
@@ -1,0 +1,29 @@
+defmodule Mix.Tasks.Nerves.Loadconfig do
+  use Mix.Task
+
+  def run(args) do
+    System.get_env("MIX_TARGET")
+    |> init()
+    Mix.Task.run("loadconfig", args)
+  end
+
+  def init(nil), do: :noop
+  def init("host"), do: :noop
+  def init(target) do
+    Mix.shell.info([:green, """
+    Nerves environment
+      MIX_TARGET:   #{target}
+      MIX_ENV:      #{Mix.env}
+    """, :reset])
+
+    configure_project(Mix.ProjectStack.peek())
+  end
+
+  def configure_project(nil), do: :ok
+  def configure_project(_) do
+    %{name: name, config: config, file: file} = Mix.ProjectStack.pop()
+    config = update_in(config, [:aliases], &Nerves.Bootstrap.add_aliases(&1))
+    Mix.ProjectStack.push(name, config, file)
+  end
+
+end

--- a/lib/mix/tasks/nerves/precompile.ex
+++ b/lib/mix/tasks/nerves/precompile.ex
@@ -53,12 +53,7 @@ defmodule Mix.Tasks.Nerves.Precompile do
         
         Also update your mix.exs target aliases to:
         
-        defp aliases(_target) do
-          [
-            # Add custom mix aliases here
-          ]
-          |> Nerves.Bootstrap.add_aliases()
-        end
+        aliases: ["loadconfig": ["nerves.loadconfig"]]
 
       """)
     end

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -38,37 +38,11 @@ defmodule Nerves.Bootstrap do
     end
   end
 
-  def deps_update(args) do
-    Mix.Tasks.Deps.Update.run(args)
-    Mix.Tasks.Nerves.Deps.Get.run([])
-  end
+  
 
   @doc """
   Add the required Nerves bootstrap aliases to the existing ones
   """
-  def add_aliases(aliases) do
-    aliases
-    |> append("deps.get", "nerves.deps.get")
-    |> prepend("deps.loadpaths", "nerves.loadpaths")
-    |> replace("deps.update", &Nerves.Bootstrap.deps_update/1)
-  end
+  defdelegate add_aliases(aliases), to: Nerves.Bootstrap.Aliases
   
-  defp append(aliases, a, na) do
-    key = String.to_atom(a)
-    Keyword.update(aliases, key, [a, na], &(drop(&1, na) ++ [na]))
-  end
-  
-  defp prepend(aliases, a, na) do
-    key = String.to_atom(a)
-    Keyword.update(aliases, key, [na, a], &([na | drop(&1, na)]))
-  end
-
-  defp replace(aliases, a, fun) do
-    key = String.to_atom(a)
-    Keyword.update(aliases, key, [fun], &(drop(&1, fun) ++ [fun]))
-  end
-
-  defp drop(aliases, a) do
-    Enum.reject(aliases, &(&1 === a))
-  end
 end

--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -1,0 +1,34 @@
+defmodule Nerves.Bootstrap.Aliases do
+  
+  def add_aliases(aliases) do
+    aliases
+    |> append("deps.get", "nerves.deps.get")
+    |> prepend("deps.loadpaths", "nerves.loadpaths")
+    |> replace("deps.update", &Nerves.Bootstrap.Aliases.deps_update/1)
+  end
+
+  def deps_update(args) do
+    Mix.Tasks.Deps.Update.run(args)
+    Mix.Tasks.Nerves.Deps.Get.run([])
+  end
+  
+  defp append(aliases, a, na) do
+    key = String.to_atom(a)
+    Keyword.update(aliases, key, [a, na], &(drop(&1, na) ++ [na]))
+  end
+  
+  defp prepend(aliases, a, na) do
+    key = String.to_atom(a)
+    Keyword.update(aliases, key, [na, a], &([na | drop(&1, na)]))
+  end
+
+  defp replace(aliases, a, fun) do
+    key = String.to_atom(a)
+    Keyword.update(aliases, key, [fun], &(drop(&1, fun) ++ [fun]))
+  end
+
+  defp drop(aliases, a) do
+    Enum.reject(aliases, &(&1 === a))
+  end
+
+end

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -3,16 +3,6 @@ defmodule <%= app_module %>.MixProject do
 
   @target System.get_env("MIX_TARGET") || "host"
 
-  Mix.shell().info([
-    :green,
-    """
-    Mix environment
-      MIX_TARGET:   #{@target}
-      MIX_ENV:      #{Mix.env()}
-    """,
-    :reset
-  ])
-
   def project do
     [
       app: :<%= app_name %>,
@@ -29,7 +19,7 @@ defmodule <%= app_module %>.MixProject do
       lockfile: "mix.lock.#{@target}",<% end %>
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      aliases: aliases(@target),
+      aliases: ["loadconfig": "nerves.loadconfig"],
       deps: deps()
     ]
   end
@@ -69,13 +59,4 @@ defmodule <%= app_module %>.MixProject do
 <% end %>
   defp system(target), do: Mix.raise "Unknown MIX_TARGET: #{target}"
 
-  # We do not invoke the Nerves Env when running on the Host
-  defp aliases("host"), do: []
-
-  defp aliases(_target) do
-    [
-      # Add custom mix aliases here
-    ]
-    |> Nerves.Bootstrap.add_aliases()
-  end
 end

--- a/test/nerves_bootstrap_test.exs
+++ b/test/nerves_bootstrap_test.exs
@@ -4,7 +4,7 @@ defmodule Nerves.BootstrapTest do
   test "aliases are injected properly" do
     deps_loadpaths = ["nerves.loadpaths", "deps.loadpaths"]
     deps_get = ["deps.get", "nerves.deps.get"]
-    deps_update = [&Nerves.Bootstrap.deps_update/1]
+    deps_update = [&Nerves.Bootstrap.Aliases.deps_update/1]
  
     aliases = Nerves.Bootstrap.add_aliases([])
     assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
@@ -23,14 +23,14 @@ defmodule Nerves.BootstrapTest do
 
     assert Keyword.get(aliases, :"deps.loadpaths") == ["nerves.loadpaths", "custom", "deps.loadpaths"]
     assert Keyword.get(aliases, :"deps.get") == ["deps.get", "custom", "nerves.deps.get"]
-    assert Keyword.get(aliases, :"deps.update") == ["custom", &Nerves.Bootstrap.deps_update/1]
+    assert Keyword.get(aliases, :"deps.update") == ["custom", &Nerves.Bootstrap.Aliases.deps_update/1]
     assert Keyword.get(aliases, :"custom") == ["custom"]
   end
 
   test "aliases are dropped if they already exist" do
     deps_loadpaths = ["nerves.loadpaths", "deps.loadpaths"]
     deps_get = ["deps.get", "nerves.deps.get"]
-    deps_update = [&Nerves.Bootstrap.deps_update/1]
+    deps_update = [&Nerves.Bootstrap.Aliases.deps_update/1]
     nerves_aliases = [
       "deps.loadpaths": deps_loadpaths
     ]


### PR DESCRIPTION
As discussed in this PR
https://github.com/nerves-project/nerves_bootstrap/pull/13

aliasing `loadconfig` would
* Remove calls to archive code from the mix file.
* clean up aliases and allow them to be maintained by the archive.

I have also moved some information code here from the mix file to inform the user that the archive aliases were loaded.