### PR TITLE
make loadconfig safe

### DIFF
--- a/lib/mix/tasks/nerves/precompile.ex
+++ b/lib/mix/tasks/nerves/precompile.ex
@@ -45,7 +45,18 @@ defmodule Mix.Tasks.Nerves.Precompile do
         
         Also update your mix.exs target aliases to:
         
-        aliases: ["loadconfig": ["nerves.loadconfig"]]
+        aliases: ["loadconfig": [&loadconfig/1]]
+
+        and add the following function to your mix file
+
+        def loadconfig(args) do
+          try do
+            Mix.Tasks.Nerves.Loadconfig.run(args)
+          rescue
+            _ ->
+            Mix.Tasks.Loadconfig.run(args)
+          end
+        end
 
       """)
     end

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -19,9 +19,18 @@ defmodule <%= app_module %>.MixProject do
       lockfile: "mix.lock.#{@target}",<% end %>
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      aliases: ["loadconfig": "nerves.loadconfig"],
+      aliases: ["loadconfig": &loadconfig/1],
       deps: deps()
     ]
+  end
+
+  def loadconfig(args) do
+    try do
+      Mix.Tasks.Nerves.Loadconfig.run(args)
+    rescue
+      _ ->
+      Mix.Tasks.Loadconfig.run(args)
+    end
   end
 
   # Run "mix help compile.app" to learn about applications.


### PR DESCRIPTION
If aliasing loadconfig directly we risk being in a similar situation where the archive.check never gets called. Additionally, we cannot hook into archive.check because it happens _after_ deps.get, which is too late for modifying the aliases. This is the safest way I can come up with.