### PR TITLE
Alias deps.get and deps.update regardless of target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nerves_bootstrap
 
+## v0.8.1
+
+  * Bug Fixes
+    * `deps.get` and `deps.update` aliases should always be added to the 
+      project regardless of target.
+
 ## v0.8.0
 
 The v0.7.x and earlier releases only required two aliases in your `mix.exs` to

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Nerves.Bootstrap.Mixfile do
   def project do
     [
       app: :nerves_bootstrap,
-      version: "0.8.0",
+      version: "0.8.1-dev",
       elixir: "~> 1.4",
       aliases: aliases(),
       xref: [exclude: [Nerves.Env]],


### PR DESCRIPTION
This addresses an issue where artifacts for toolchains were not being fetched when the top level project is a Nerves package such as a custom system. In any case, we should attempt to resolve artifacts for any Nerves package that exists in the deps tree.