### PR TITLE
Check packages for precompiled artifacts and raise if missing

### DIFF
--- a/lib/mix/nerves/io.ex
+++ b/lib/mix/nerves/io.ex
@@ -5,6 +5,8 @@ defmodule Mix.Nerves.IO do
     if System.get_env("NERVES_DEBUG") == "1" do
       shell_info(header, text, loc)
     end
+
+    :ok
   end
 
   def shell_info(header, text \\ "", loc \\ @app) do

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -5,7 +5,7 @@ defmodule Nerves.Bootstrap do
 
   # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications
-  @moduledoc false  
+  @moduledoc false
 
   def start(_type, _args) do
     Nerves.Bootstrap.Aliases.init()

--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -1,31 +1,30 @@
 defmodule Nerves.Bootstrap.Aliases do
-  
   def init() do
-    with \
-      %{} <- Mix.ProjectStack.peek(),
-      %{name: name, config: config, file: file} <- Mix.ProjectStack.pop(),
-      nil <- Mix.ProjectStack.peek() do
-      
+    with %{} <- Mix.ProjectStack.peek(),
+         %{name: name, config: config, file: file} <- Mix.ProjectStack.pop(),
+         nil <- Mix.ProjectStack.peek() do
       target = System.get_env("MIX_TARGET")
-      
-      config = 
+
+      config =
         config
         |> host_config()
         |> target_config(target)
-      
+
       Mix.ProjectStack.push(name, config, file)
     else
       # We are not at the top of the stack. Do nothing.
-      _ -> :noop
+      _ ->
+        :noop
     end
   end
-  
+
   def host_config(config) do
     update_in(config, [:aliases], &add_host_aliases(&1))
   end
 
   def target_config(config, nil), do: config
   def target_config(config, "host"), do: config
+
   def target_config(config, target) do
     Mix.shell().info([
       :green,
@@ -36,6 +35,7 @@ defmodule Nerves.Bootstrap.Aliases do
       """,
       :reset
     ])
+
     update_in(config, [:aliases], &add_target_aliases(&1))
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,10 +4,10 @@ defmodule Nerves.Bootstrap.Mixfile do
   def project do
     [
       app: :nerves_bootstrap,
-      version: "0.8.1",
+      version: "0.8.2-dev",
       elixir: "~> 1.4",
       aliases: aliases(),
-      xref: [exclude: [Nerves.Env]],
+      xref: [exclude: [Nerves.Env, Nerves.Artifact]],
       description: description(),
       package: package(),
       deps: deps()


### PR DESCRIPTION
Currently, nerves will compile any nerves_package that is missing a precompiled artifact or the calculated hash of the source does not match that of the artifact. 

The benefit of halting compilation if an artifact is missing is that it will put more control in to the distribution and prevent new users from unknowingly entering a very long and very large compile. 

This check occurs early, in precompile, and will raise a `Mix.Error` if any dependencies that have the `nerves_package` compiler in their `:compilers` list are found to be missing the artifact or whos sources have been altered from the checksum of the artifact on disk.

To force compilation to happen, the top level project needs to add `nerves_compile: true` to the `opts` of the dependency. For example

```elixir
{:nerves_system_rpi0, "~> 0.20.0", nerves: [compile: true]}
```