### PR TITLE
check for update should only return non pre release versions

### DIFF
--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -18,6 +18,11 @@ defmodule Nerves.Bootstrap do
   def version, do: @version
 
   @doc """
+  Add the required Nerves bootstrap aliases to the existing ones
+  """
+  defdelegate add_aliases(aliases), to: Nerves.Bootstrap.Aliases
+
+  @doc """
   Check the nerves_bootstrap updates from hex
   """
   def check_for_update() do
@@ -25,34 +30,76 @@ defmodule Nerves.Bootstrap do
       Hex.start()
       {:ok, {200, resp, _}} = Hex.API.Package.get("hexpm", "nerves_bootstrap")
 
-      latest_rel =
-        resp
-        |> Map.get("releases")
-        |> List.first()
-
-      latest_vsn =
-        Map.get(latest_rel, "version")
-        |> Version.parse!()
-
-      current_vsn =
+      current_version =
         Nerves.Bootstrap.version()
         |> Version.parse!()
 
-      if Version.compare(current_vsn, latest_vsn) == :lt do
-        Mix.shell().info([
-          IO.ANSI.yellow(),
-          "A new version of Nerves bootstrap is available(#{current_vsn} < #{latest_vsn}), " <>
-            "please update with `mix local.nerves`",
-          IO.ANSI.reset()
-        ])
+      release_versions =
+        resp
+        |> Map.get("releases")
+        |> Enum.map(&Map.get(&1, "version"))
+        |> Enum.map(&Version.parse!/1)
+
+      case check_for_update(release_versions, current_version) do
+        nil ->
+          :noop
+
+        latest_version ->
+          render_update_message(current_version, latest_version)
       end
     rescue
       _e -> :noop
     end
   end
 
-  @doc """
-  Add the required Nerves bootstrap aliases to the existing ones
-  """
-  defdelegate add_aliases(aliases), to: Nerves.Bootstrap.Aliases
+  def check_for_update(releases, current_version) do
+    releases
+    |> filter_pre_release(current_version)
+    |> Enum.filter(&(Version.compare(&1, current_version) == :gt))
+    |> Enum.sort(&(Version.compare(&1, &2) == :gt))
+    |> List.first()
+  end
+
+  def render_update_message(current_version, %{pre: pre} = latest_version) do
+    message =
+      "A new version of Nerves bootstrap is available(#{current_version} < #{latest_version}), " <>
+        if pre == [] do
+          """
+          You can update by running
+            
+            mix local.nerves
+          """
+        else
+          """
+          You can update by running
+            
+            mix archive.install hex nerves_bootstrap #{latest_version}
+          """
+        end
+
+    Mix.shell().info([
+      IO.ANSI.yellow(),
+      message,
+      IO.ANSI.reset()
+    ])
+  end
+
+  defp filter_pre_release(releases, %{pre: []}) do
+    releases
+    |> Enum.filter(&(Map.get(&1, :pre) == []))
+  end
+
+  defp filter_pre_release(releases, %{major: major, minor: minor, patch: patch}) do
+    releases
+    |> Enum.filter(fn
+      %{pre: []} ->
+        true
+
+      %{major: ^major, minor: ^minor, patch: ^patch} ->
+        true
+
+      _ ->
+        false
+    end)
+  end
 end

--- a/test/nerves_bootstrap_test.exs
+++ b/test/nerves_bootstrap_test.exs
@@ -52,4 +52,75 @@ defmodule Nerves.BootstrapTest do
     assert Keyword.get(aliases, :"deps.get") == deps_get
     assert Keyword.get(aliases, :"deps.update") == deps_update
   end
+
+  test "check for update will exclude pre release" do
+    current_version = Version.parse!("0.8.0")
+
+    releases = [
+      "0.8.2",
+      "1.0.0-rc.0",
+      "0.8.1"
+    ]
+
+    releases = Enum.map(releases, &Version.parse!/1)
+    assert %{minor: 8, patch: 2} = Nerves.Bootstrap.check_for_update(releases, current_version)
+  end
+
+  test "check for update will include pre release if on pre" do
+    current_version = Version.parse!("1.0.0-rc.0")
+
+    releases = [
+      "1.1.0-rc.0",
+      "1.0.0-rc.1",
+      "0.8.2",
+      "1.0.0-rc.0",
+      "0.8.1"
+    ]
+
+    releases = Enum.map(releases, &Version.parse!/1)
+
+    assert %{minor: 0, pre: ["rc", 1]} =
+             Nerves.Bootstrap.check_for_update(releases, current_version)
+  end
+
+  test "check for update moving from pre to stable" do
+    current_version = Version.parse!("1.0.0-rc.0")
+
+    releases = [
+      "1.0.0",
+      "1.0.0-rc.1",
+      "0.8.2",
+      "1.0.0-rc.0",
+      "0.8.1"
+    ]
+
+    releases = Enum.map(releases, &Version.parse!/1)
+
+    assert %{major: 1, minor: 0, patch: 0, pre: []} =
+             Nerves.Bootstrap.check_for_update(releases, current_version)
+  end
+
+  test "check for update excluding pre release message" do
+    current_version = Version.parse!("0.8.0")
+    latest_version = Version.parse!("0.8.1")
+    Nerves.Bootstrap.render_update_message(current_version, latest_version)
+    assert_receive {:mix_shell, :info, [message]}
+    assert message =~ "mix local.nerves"
+  end
+
+  test "check for update including pre release message" do
+    current_version = Version.parse!("1.0.0-rc.0")
+    latest_version = Version.parse!("1.0.0-rc.1")
+    Nerves.Bootstrap.render_update_message(current_version, latest_version)
+    assert_receive {:mix_shell, :info, [message]}
+    assert message =~ "mix archive.install hex nerves_bootstrap 1.0.0-rc.1"
+  end
+
+  test "check for update moving from pre to stable message" do
+    current_version = Version.parse!("1.0.0-rc.0")
+    latest_version = Version.parse!("1.0.0")
+    Nerves.Bootstrap.render_update_message(current_version, latest_version)
+    assert_receive {:mix_shell, :info, [message]}
+    assert message =~ "mix local.nerves"
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+Mix.shell(Mix.Shell.Process)
+
 ExUnit.start()


### PR DESCRIPTION
Currently, the update check includes a warning that an update is available for `1.0.0-rc.0` this will prevent this in the future.