### PR TITLE
Check for updates after 1.0.0-rc.0

### DIFF
--- a/lib/mix/tasks/nerves/local.ex
+++ b/lib/mix/tasks/nerves/local.ex
@@ -13,6 +13,6 @@ defmodule Mix.Tasks.Local.Nerves do
   This accepts the same command line options as `archive.install`.
   """
   def run(_args) do
-    Mix.Task.run("archive.install", ["hex", "nerves_bootstrap"])
+    Mix.Task.run("archive.install", ["hex", "nerves_bootstrap", "~> 1.0-rc.0"])
   end
 end


### PR DESCRIPTION
Before when you'd run `mix local.nerves`, you'd get 0.8.2. Now you get
1.0.0-rc.1.