### PR TITLE
remove build_embedded from generated mix file

### DIFF
--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -17,7 +17,6 @@ defmodule <%= app_module %>.MixProject do
       deps_path: "deps/#{@target}",
       build_path: "_build/#{@target}",
       lockfile: "mix.lock.#{@target}",<% end %>
-      build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       aliases: [loadconfig: [&bootstrap/1]],
       deps: deps()


### PR DESCRIPTION
It was brought to my attention that `build_embedded` is no longer needed.