### PR TITLE
Automatically load the Nerves IEx helpers

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -30,6 +30,7 @@ defmodule Mix.Tasks.Nerves.New do
     {:eex, "new/test/test_helper.exs", "test/test_helper.exs"},
     {:eex, "new/test/app_name_test.exs", "test/app_name_test.exs"},
     {:eex, "new/rel/vm.args", "rel/vm.args"},
+    {:eex, "new/rootfs_overlay/etc/iex.exs", "rootfs_overlay/etc/iex.exs"},
     {:text, "new/.gitignore", ".gitignore"},
     {:text, "new/.formatter.exs", ".formatter.exs"},
     {:eex, "new/mix.exs", "mix.exs"},

--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -9,8 +9,8 @@ use Mix.Config
 # to add files to the root filesystem or modify the firmware
 # archive.
 
-# config :nerves, :firmware,
-#   rootfs_overlay: "rootfs_overlay",
+config :nerves, :firmware,
+  rootfs_overlay: "rootfs_overlay"
 #   fwup_conf: "config/fwup.conf"
 
 # Use shoehorn to start the main application. See the shoehorn

--- a/templates/new/rel/vm.args
+++ b/templates/new/rel/vm.args
@@ -23,6 +23,11 @@
 ## Enable colors in the shell
 -elixir ansi_enabled true
 
-## Options added after -extra are interpreted as plain arguments and
-## can be retrieved using :init.get_plain_arguments().
+## Options added after -extra are interpreted as plain arguments and # can be
+## retrieved using :init.get_plain_arguments(). Options before # the "--" are
+## interpreted by Elixir and anything afterwards is left # around for other IEx
+## and user applications.
 -extra --no-halt
+--
+--dot-iex /etc/iex.exs
+

--- a/templates/new/rootfs_overlay/etc/iex.exs
+++ b/templates/new/rootfs_overlay/etc/iex.exs
@@ -1,0 +1,5 @@
+# Pull in Nerves-specific helpers to the IEx session
+use Nerves.Runtime.Helpers
+
+# Be careful when adding to this file. Nearly any error can crash the VM and
+# cause a reboot.


### PR DESCRIPTION
This has a few side effects:

1. A `rootfs_overlay` folder is created.
2. `/root/.iex.exs` is no longer read.
3. Some more comments about passing arguments via vm.args were added.

Preventing `/root/.iex.exs` is a safety feature, since errors in that
file caused reboots and could easily brick boards that didn't have
automatic image fallbacks enabled (i.e. all official systems).

The automatical load of the helpers makes the helpers available on the
first boot. It is expected to be safe since `nerves_runtime` is one of
the most exercised Nerves packages.