### PR TITLE
Add commented out reference to heart

### DIFF
--- a/templates/new/rel/vm.args
+++ b/templates/new/rel/vm.args
@@ -15,6 +15,9 @@
 ## See http://erlang.org/doc/man/kernel_app.html for additional options
 -kernel shell_history enabled
 
+## Enable heartbeat monitoring of the Erlang runtime system
+#-heart -env HEART_BEAT_TIMEOUT 30
+
 ## Start the Elixir shell
 
 -noshell

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -80,4 +80,14 @@ defmodule Nerves.NewTest do
       end)
     end)
   end
+
+  test "new project adds comment about enabling heart", context do
+    in_tmp(context.test, fn ->
+      Mix.Tasks.Nerves.New.run([@app_name])
+
+      assert_file("#{@app_name}/rel/vm.args", fn file ->
+        assert file =~ "#-heart -env HEART_BEAT_TIMEOUT"
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
At some point we may choose to enable this by default, but the idea for
now is to inform Nerves users that the capability exists.