### PR TITLE
Add :runtime_tools to the extra_applications

### DIFF
--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -42,7 +42,10 @@ defmodule <%= app_module %>.MixProject do
   end
 
   def application(_target) do
-    [mod: {<%= app_module %>.Application, []}, extra_applications: [:logger]]
+    [
+      mod: {<%= app_module %>.Application, []},
+      extra_applications: [:logger, :runtime_tools]
+    ]
   end
 
   # Run "mix help deps" to learn about dependencies.

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -90,4 +90,15 @@ defmodule Nerves.NewTest do
       end)
     end)
   end
+
+  test "new project adds runtime_tools", context do
+    in_tmp(context.test, fn ->
+      Mix.Tasks.Nerves.New.run([@app_name])
+
+      assert_file("#{@app_name}/mix.exs", fn file ->
+        assert file =~ ~r"extra_applications:.*runtime_tools"
+      end)
+    end)
+  end
+
 end


### PR DESCRIPTION
Fix the #1 issue when trying to use :observer.