### PR TITLE
Format/comment rootfs_overlay config

### DIFF
--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -5,13 +5,9 @@
 # is restricted to this project.
 use Mix.Config
 
-# Customize the firmware. Uncomment all or parts of the following
-# to add files to the root filesystem or modify the firmware
-# archive.
-
-config :nerves, :firmware,
-  rootfs_overlay: "rootfs_overlay"
-#   fwup_conf: "config/fwup.conf"
+# Customize non-Elixir parts of the firmware.  See
+# https://hexdocs.pm/nerves/advanced-configuration.html for details.
+config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 
 # Use shoehorn to start the main application. See the shoehorn
 # docs for separating out critical OTP applications such as those


### PR DESCRIPTION
This section of the template would change on a `mix format`. This fixes
that issue and points people to the docs now.