### PR TITLE
Define supervisor children by target instead of application/0

### DIFF
--- a/templates/new/lib/app_name/application.ex
+++ b/templates/new/lib/app_name/application.ex
@@ -3,18 +3,29 @@ defmodule <%= app_module %>.Application do
   # for more information on OTP Applications
   @moduledoc false
 
+  @target Mix.Project.config()[:target]
+
   use Application
 
   def start(_type, _args) do
-    # List all child processes to be supervised
-    children = [
-      # Starts a worker by calling: <%= app_module %>.Worker.start_link(arg)
-      # {<%= app_module %>.Worker, arg},
-    ]
-
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: <%= app_module %>.Supervisor]
-    Supervisor.start_link(children, opts)
+    Supervisor.start_link(children(@target), opts)
+  end
+
+  # List all child processes to be supervised
+  def children("host") do
+    [
+      # Starts a worker by calling: <%= app_module %>.Worker.start_link(arg)
+      # {<%= app_module %>.Worker, arg},
+    ]
+  end
+
+  def children(_target) do
+    [
+      # Starts a worker by calling: <%= app_module %>.Worker.start_link(arg)
+      # {<%= app_module %>.Worker, arg},
+    ]
   end
 end

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -31,17 +31,7 @@ defmodule <%= app_module %>.MixProject do
   end
 
   # Run "mix help compile.app" to learn about applications.
-  def application, do: application(@target)
-
-  # Specify target specific application configurations
-  # It is common that the application start function will start and supervise
-  # applications which could cause the host to fail. Because of this, we only
-  # invoke <%= app_module %>.start/2 when running on a target.
-  def application("host") do
-    [extra_applications: [:logger]]
-  end
-
-  def application(_target) do
+  def application do
     [
       mod: {<%= app_module %>.Application, []},
       extra_applications: [:logger, :runtime_tools]

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -40,7 +40,10 @@ defmodule <%= app_module %>.MixProject do
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
-    [<%= nerves_dep %>] ++ deps(@target)
+    [
+      <%= nerves_dep %>,
+      {:shoehorn, "~> <%= shoehorn_vsn %>"}
+    ] ++ deps(@target)
   end
 
   # Specify target specific dependencies
@@ -48,7 +51,6 @@ defmodule <%= app_module %>.MixProject do
 
   defp deps(target) do
     [
-      {:shoehorn, "~> <%= shoehorn_vsn %>"},
       {:nerves_runtime, "~> <%= runtime_vsn %>"}
     ] ++ system(target)
   end


### PR DESCRIPTION
Fixes https://github.com/nerves-project/nerves_bootstrap/issues/42

This PR also moves the `shoehorn` dependency to be included for all targets including `host`