### PR TITLE
update references for provider to build_runner

### DIFF
--- a/lib/mix/tasks/nerves/env.ex
+++ b/lib/mix/tasks/nerves/env.ex
@@ -46,10 +46,10 @@ defmodule Mix.Tasks.Nerves.Env do
 
   defp print_pkg(pkg) do
     Mix.shell().info("""
-      Pkg:      #{pkg.app}
-      Vsn:      #{pkg.version}
-      Type:     #{pkg.type}
-      Provider: #{inspect(pkg.provider)}
+      Pkg:         #{pkg.app}
+      Vsn:         #{pkg.version}
+      Type:        #{pkg.type}
+      BuildRunner: #{inspect(pkg.build_runner)}
     """)
   end
 end

--- a/lib/mix/tasks/nerves/system.shell.ex
+++ b/lib/mix/tasks/nerves/system.shell.ex
@@ -70,9 +70,9 @@ defmodule Mix.Tasks.Nerves.System.Shell do
       end
     end
 
-    {provider, _opts} = pkg.provider
+    {build_runner, _opts} = pkg.build_runner
 
-    provider.system_shell(pkg)
+    build_runner.system_shell(pkg)
 
     # Set :user back to the real one
     Process.register(user, :user)


### PR DESCRIPTION
Due to an issue with order of operations, the task for `nerves.system.shell` lives in the archive. This PR updates missed referenced to `provider` by changing them to `build_runner`