### PR TITLE
Add support for generating new projects with nerves_init_gadget

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -8,6 +8,7 @@ defmodule Mix.Tasks.Nerves.New do
   @shoehorn_vsn "0.4"
   @bootstrap_vsn "1.0"
   @runtime_vsn "0.6"
+  @init_gadget_vsn "0.4"
 
   @requirement Mix.Project.config()[:elixir]
   @shortdoc "Creates a new Nerves application"
@@ -68,6 +69,9 @@ defmodule Mix.Tasks.Nerves.New do
   A `--cookie` options can be given to set the Erlang distribution
   cookie in `vm.args`. This defaults to a randomly generated string.
 
+  Generate a project preloaded with `nerves_init_gadget` support by passing
+  `--init-gadget`. 
+
   ## Examples
 
       mix nerves.new blinky
@@ -76,6 +80,9 @@ defmodule Mix.Tasks.Nerves.New do
 
       mix nerves.new blinky --module Blinky
 
+  Generate a project configured to use `nerves_init_gadget`
+
+      mix nerves.new blinky --init-gadget
 
   Generate a project that only supports Raspberry Pi 3
 
@@ -86,7 +93,13 @@ defmodule Mix.Tasks.Nerves.New do
       mix nerves.new blinky --target rpi3 --target rpi0
   """
 
-  @switches [app: :string, module: :string, target: :keep, cookie: :string]
+  @switches [
+    app: :string,
+    module: :string,
+    target: :keep,
+    cookie: :string,
+    init_gadget: :boolean
+  ]
 
   def run([version]) when version in ~w(-v --version) do
     Mix.shell().info("Nerves v#{@bootstrap_vsn}")
@@ -129,6 +142,7 @@ defmodule Mix.Tasks.Nerves.New do
 
     nerves_path = nerves_path(path, Keyword.get(opts, :dev, false))
     in_umbrella? = in_umbrella?(path)
+    init_gadget? = opts[:init_gadget] || false
 
     targets = Keyword.get_values(opts, :target)
 
@@ -156,6 +170,8 @@ defmodule Mix.Tasks.Nerves.New do
       elixir_req: @requirement,
       nerves_dep: nerves_dep(nerves_path),
       in_umbrella: in_umbrella?,
+      init_gadget?: init_gadget?,
+      init_gadget_vsn: @init_gadget_vsn,
       targets: targets,
       cookie: cookie
     ]

--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -13,8 +13,38 @@ config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 # docs for separating out critical OTP applications such as those
 # involved with firmware updates.
 config :shoehorn,
-  init: [:nerves_runtime],
-  app: Mix.Project.config()[:app]
+  init: [:nerves_runtime<%= if init_gadget? do %>, :nerves_init_gadget<% end %>],
+  app: Mix.Project.config()[:app]<%= if init_gadget? do %>
+
+# Authorize the device to receive firmware using your public key.
+# See https://hexdocs.pm/nerves_firmware_ssh/readme.html for more information
+# on configuring nerves_firmware_ssh.
+
+key = Path.join(System.user_home!, ".ssh/id_rsa.pub")
+unless File.exists?(key), do: 
+  Mix.raise("No SSH Keys found. Please generate an ssh key")
+
+config :nerves_firmware_ssh,
+  authorized_keys: [
+    File.read!(key)
+  ]
+
+# Use Ringlogger as the logger backend and remove :console.
+# See https://hexdocs.pm/ring_logger/readme.html for more information on
+# configuring ring_logger.
+
+config :logger, backends: [RingLogger]
+
+# Configure nerves_init_gadget.
+# See https://hexdocs.pm/nerves_init_gadget/readme.html for more information.
+
+config :nerves_init_gadget,
+  ifname: "usb0",
+  address_method: :linklocal,
+  mdns_domain: "nerves.local",
+  node_name: nil,
+  node_host: :mdns_domain,
+  ssh_console_port: 22<% end %>
 
 # Import target specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -51,7 +51,8 @@ defmodule <%= app_module %>.MixProject do
 
   defp deps(target) do
     [
-      {:nerves_runtime, "~> <%= runtime_vsn %>"}
+      {:nerves_runtime, "~> <%= runtime_vsn %>"}<%= if init_gadget? do %>,
+      {:nerves_init_gadget, "~> <%= init_gadget_vsn %>"}<% end %>
     ] ++ system(target)
   end
 

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -100,4 +100,20 @@ defmodule Nerves.NewTest do
       end)
     end)
   end
+
+  test "new project init gadget", context do
+    in_tmp(context.test, fn ->
+      Mix.Tasks.Nerves.New.run([@app_name, "--init-gadget"])
+
+      assert_file("#{@app_name}/mix.exs", fn file ->
+        assert file =~ ~r"nerves_init_gadget"
+      end)
+
+      assert_file("#{@app_name}/config/config.exs", fn file ->
+        assert file =~ ~r"nerves_init_gadget"
+        assert file =~ ~r"nerves_firmware_ssh"
+        assert file =~ ~r"RingLogger"
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
This PR allows you to create new projects that include `nerves_init_gadget`. It will add `nerves_init_gadget` to the deps and also include some helpful configuration to the `config.exs`.

You can create a project with this by running `mix nerves.new my_app --init-gadget`