### PR TITLE
Generate cookies without symbols

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -354,6 +354,8 @@ defmodule Mix.Tasks.Nerves.New do
   end
 
   defp random_string(length) do
-    :crypto.strong_rand_bytes(length) |> Base.encode64() |> binary_part(0, length)
+    :crypto.strong_rand_bytes(length)
+    |> Base.encode32(case: :lower, padding: false)
+    |> binary_part(0, length)
   end
 end


### PR DESCRIPTION
It's frustrating when using Erlang distribution to copy/paste and use
cookies that have symbols in them. They don't copy/paste correctly and
the symbols need to be escaped. To avoid this, change the auto-generated
cookie to be base32 encoded rather than base64.

The resulting cookie has 320 random bits instead of 384. I think that
anyone bothered by this can replace the cookie with their own.