### PR TITLE
Print message about using ring logger to console

### DIFF
--- a/templates/new/rootfs_overlay/etc/iex.exs
+++ b/templates/new/rootfs_overlay/etc/iex.exs
@@ -1,5 +1,18 @@
 # Pull in Nerves-specific helpers to the IEx session
 use Nerves.Runtime.Helpers
 
+if RingLogger in Application.get_env(:logger, :backends, []) do
+  IO.puts """
+  RingLogger is collecting log messages from Elixir and Linux. To see the
+  messages, either attach the current IEx session to the logger:
+
+    RingLogger.attach
+
+  or tail the log:
+
+    RingLogger.tail
+  """
+end
+
 # Be careful when adding to this file. Nearly any error can crash the VM and
 # cause a reboot.


### PR DESCRIPTION
If the ring logger backend is enabled, print a message to the console about using ringlogger.