### PR TITLE
Set build_embedded: true when deploying to target.

### DIFF
--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -18,6 +18,7 @@ defmodule <%= app_module %>.MixProject do
       build_path: "_build/#{@target}",
       lockfile: "mix.lock.#{@target}",<% end %>
       start_permanent: Mix.env() == :prod,
+      build_embedded: @target != "host",
       aliases: [loadconfig: [&bootstrap/1]],
       deps: deps()
     ]


### PR DESCRIPTION
This fixes an issue when using path dependencies that use
more dependencies that use code that needs to be cross compiled.

[Relevant issue
thread](https://github.com/elixir-lang/elixir/issues/8160)