### PR TITLE
Add flag for embedded mode

### DIFF
--- a/templates/new/rel/vm.args
+++ b/templates/new/rel/vm.args
@@ -1,5 +1,9 @@
 ## Add custom options here
 
+## Embedded Mode
+##  BEAM will lazy load modules unless this is set
+-mode embedded
+
 ## Distributed Erlang Options
 ##  The cookie needs to be configured prior to vm boot for
 ##  for read only filesystem.


### PR DESCRIPTION
BEAM defaults to "interactive" mode, which will lazy load modules.  This can dramatically slow down boot times, as well well as modules like Absinthe