### PR TITLE
Enable heart by default

### DIFF
--- a/templates/new/rel/vm.args
+++ b/templates/new/rel/vm.args
@@ -20,7 +20,7 @@
 -kernel shell_history enabled
 
 ## Enable heartbeat monitoring of the Erlang runtime system
-#-heart -env HEART_BEAT_TIMEOUT 30
+-heart -env HEART_BEAT_TIMEOUT 30
 
 ## Start the Elixir shell
 

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -81,12 +81,12 @@ defmodule Nerves.NewTest do
     end)
   end
 
-  test "new project adds comment about enabling heart", context do
+  test "new project enables heart", context do
     in_tmp(context.test, fn ->
       Mix.Tasks.Nerves.New.run([@app_name])
 
       assert_file("#{@app_name}/rel/vm.args", fn file ->
-        assert file =~ "#-heart -env HEART_BEAT_TIMEOUT"
+        assert file =~ "-heart -env HEART_BEAT_TIMEOUT"
       end)
     end)
   end


### PR DESCRIPTION
Many of us have been using heart for months. It has definite benefits in ensuring that systems remain online so default it to on in new projects.