### PR TITLE
Use dhcpd instead of linklocal for defaults

### DIFF
--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -42,7 +42,7 @@ config :nerves_firmware_ssh,
 
 config :nerves_init_gadget,
   ifname: "usb0",
-  address_method: :linklocal,
+  address_method: :dhcpd,
   mdns_domain: "nerves.local",
   node_name: nil,
   node_host: :mdns_domain,


### PR DESCRIPTION
Because of https://github.com/nerves-project/nerves_init_gadget/pull/49