### PR TITLE
Update aliases

### DIFF
--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -53,7 +53,7 @@ defmodule Nerves.Bootstrap.Aliases do
         Mix.Tasks.Run.run(args)
 
       target ->
-        Mix.raise("""
+        Mix.Nerves.IO.shell_warn("""
         You are trying to run code compiled for #{target}
         on your host. Please unset MIX_TARGET to run in host mode.
         """)

--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -43,6 +43,7 @@ defmodule Nerves.Bootstrap.Aliases do
   def add_target_aliases(aliases) do
     aliases
     |> prepend("deps.loadpaths", "nerves.loadpaths")
+    |> prepend("deps.compile", "nerves.loadpaths")
     |> replace("run", &Nerves.Bootstrap.Aliases.run/1)
   end
 

--- a/test/nerves_bootstrap_test.exs
+++ b/test/nerves_bootstrap_test.exs
@@ -5,11 +5,13 @@ defmodule Nerves.BootstrapTest do
     deps_loadpaths = ["nerves.loadpaths", "deps.loadpaths"]
     deps_get = ["deps.get", "nerves.deps.get"]
     deps_update = [&Nerves.Bootstrap.Aliases.deps_update/1]
+    deps_compile = ["nerves.loadpaths", "deps.compile"]
 
     aliases = Nerves.Bootstrap.add_aliases([])
     assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
     assert Keyword.get(aliases, :"deps.get") == deps_get
     assert Keyword.get(aliases, :"deps.update") == deps_update
+    assert Keyword.get(aliases, :"deps.compile") == deps_compile
   end
 
   test "custom aliases are maintained" do


### PR DESCRIPTION
This PR
* Fixes `deps.compile` by bringing up the Nerves env prior to calling into compile.
* Warns instead of raising when calling `mix run` with `MIX_TARGET` set to something other than host.