### PR TITLE
Update init_gadget config to set node name to app name

### DIFF
--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -40,13 +40,16 @@ config :nerves_firmware_ssh,
 # Configure nerves_init_gadget.
 # See https://hexdocs.pm/nerves_init_gadget/readme.html for more information.
 
+# Setting the node_name will enable Erlang Distribution.
+# Only enable this for prod if you understand the risks.
+node_name = if Mix.env() != :prod, do: "<%= app_name %>"
+
 config :nerves_init_gadget,
   ifname: "usb0",
   address_method: :dhcpd,
   mdns_domain: "nerves.local",
-  node_name: nil,
-  node_host: :mdns_domain,
-  ssh_console_port: 22<% end %>
+  node_name: node_name,
+  node_host: :mdns_domain<% end %>
 
 # Import target specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.


### PR DESCRIPTION
Remove unnecessary `ssh_console_port ` and set the node name to the application name by default.