### PR TITLE
Enable multi_time_warp mode to update Erlang system time

### DIFF
--- a/templates/new/rel/vm.args
+++ b/templates/new/rel/vm.args
@@ -11,6 +11,10 @@
 ## break handler and possibly exiting the VM.
 +Bc
 
+# Allow time warps so that the Erlang system time can more closely match the
+# OS system time.
++C multi_time_warp
+
 ## Load code at system startup
 ## See http://erlang.org/doc/system_principles/system_principles.html#code-loading-strategy
 -mode embedded


### PR DESCRIPTION
Since it's common for Nerves devices to not have a real-time clock,
Erlang frequently starts up in the 1970s. nerves_time and other
libraries update the OS clock. This time warp is not reflected in the
Erlang system clock by default and that can cause a lot of confusion. To
fix this, enable multi_time_warp mode. See
http://erlang.org/doc/apps/erts/time_correction.html#time-warp-modes.
This mode was chosen over single time warp mode (which would have worked
as well) due to the recommendation from the doc.

Huge thanks to Brian May for figuring out what was going on and why some
libraries would get the incorrect time.