### PR TITLE
Add support for Mix.target()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,25 @@
-# Elixir CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-elixir/ for more details
+install_elixir: &install_elixir
+  run:
+    name: Install Elixir
+    command: |
+      wget https://repo.hex.pm/builds/elixir/v$ELIXIR_VERSION.zip
+      unzip -d /usr/local/elixir v$ELIXIR_VERSION.zip
+      echo 'export PATH=/usr/local/elixir/bin:$PATH' >> $BASH_ENV
+
 version: 2
 jobs:
   build:
     docker:
-      - image: circleci/elixir:1.7
+      - image: erlang:21.2.2
+        environment:
+          ELIXIR_VERSION: 1.8.0-otp-21
+          LC_ALL: C.UTF-8
     working_directory: ~/repo
+    environment:
+      MIX_ENV: test
     steps:
       - checkout
+      - <<: *install_elixir
       - run: mix local.hex --force && mix local.rebar --force
       - run: mix deps.get --only test
       - run: mix test

--- a/lib/mix/nerves/io.ex
+++ b/lib/mix/nerves/io.ex
@@ -27,7 +27,7 @@ defmodule Mix.Nerves.IO do
       """
 
       Nerves environment
-        MIX_TARGET:   #{System.get_env("MIX_TARGET") || "unset"}
+        MIX_TARGET:   #{Nerves.Bootstrap.mix_target()}
         MIX_ENV:      #{Mix.env()}
       """,
       :reset

--- a/lib/mix/tasks/nerves/loadpaths.ex
+++ b/lib/mix/tasks/nerves/loadpaths.ex
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
 
   def env_info do
     debug_info("Environment Variable List", """
-      target:     #{Mix.Project.config()[:target] || "unset"}
+      target:     #{Nerves.Bootstrap.mix_target()}
       toolchain:  #{env("NERVES_TOOLCHAIN")}
       system:     #{env("NERVES_SYSTEM")}
       app:        #{env("NERVES_APP")}

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -4,7 +4,8 @@ defmodule Mix.Tasks.Nerves.New do
 
   @nerves Path.expand("../../../..", __DIR__)
 
-  @nerves_vsn "1.3"
+  # @nerves_vsn "1.3"
+  @nerves_dep ~s[{:nerves, github: "nerves-project/nerves", branch: "elixir-18", override: true, runtime: false}]
   @shoehorn_vsn "0.4"
   @bootstrap_vsn "1.0"
   @runtime_vsn "0.6"
@@ -16,12 +17,12 @@ defmodule Mix.Tasks.Nerves.New do
   @shortdoc "Creates a new Nerves application"
 
   @targets [
-    {"rpi", "1.5"},
-    {"rpi0", "1.5"},
-    {"rpi2", "1.5"},
-    {"rpi3", "1.5"},
-    {"bbb", "2.0"},
-    {"x86_64", "1.5"}
+    {:rpi, "1.5"},
+    {:rpi0, "1.5"},
+    {:rpi2, "1.5"},
+    {:rpi3, "1.5"},
+    {:bbb, "2.0"},
+    {:x86_64, "1.5"}
   ]
 
   @new [
@@ -146,13 +147,17 @@ defmodule Mix.Tasks.Nerves.New do
     init_gadget? = opts[:init_gadget] || false
 
     targets = Keyword.get_values(opts, :target)
+    default_targets = Keyword.keys(@targets)
 
     targets =
       Enum.map(targets, fn target ->
-        default_targets = Keyword.keys(@targets)
+        target = String.to_atom(target)
 
         unless target in default_targets do
-          targets = Enum.join(@targets, "\n")
+          targets =
+            @targets
+            |> Enum.map(&elem(&1, 0))
+            |> Enum.join("\n")
 
           Mix.raise("""
           Unknown target #{inspect(target)}
@@ -298,7 +303,7 @@ defmodule Mix.Tasks.Nerves.New do
     end
   end
 
-  defp nerves_dep("deps/nerves"), do: ~s[{:nerves, "~> #{@nerves_vsn}", runtime: false}]
+  defp nerves_dep("deps/nerves"), do: @nerves_dep
   defp nerves_dep(path), do: ~s[{:nerves, path: #{inspect(path)}, runtime: false, override: true}]
 
   defp nerves_path(path, true) do

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -4,8 +4,8 @@ defmodule Mix.Tasks.Nerves.New do
 
   @nerves Path.expand("../../../..", __DIR__)
 
-  # @nerves_vsn "1.3"
-  @nerves_dep ~s[{:nerves, github: "nerves-project/nerves", branch: "elixir-18", override: true, runtime: false}]
+  @nerves_vsn "1.4"
+  @nerves_dep ~s[{:nerves, "~> #{@nerves_vsn}", runtime: false}]
   @shoehorn_vsn "0.4"
   @bootstrap_vsn "1.0"
   @runtime_vsn "0.6"

--- a/lib/mix/tasks/nerves/system.shell.ex
+++ b/lib/mix/tasks/nerves/system.shell.ex
@@ -62,10 +62,8 @@ defmodule Mix.Tasks.Nerves.System.Shell do
     pkg = Nerves.Env.system()
 
     if is_nil(pkg) do
-      target = System.get_env("MIX_TARGET") || "host"
-
-      case target do
-        "host" -> Mix.raise(@no_mix_target_error)
+      case Nerves.Bootstrap.mix_target() do
+        :host -> Mix.raise(@no_mix_target_error)
         _ -> Mix.raise(@no_system_pkg_error)
       end
     end

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -66,13 +66,13 @@ defmodule Nerves.Bootstrap do
         if pre == [] do
           """
           You can update by running
-            
+
             mix local.nerves
           """
         else
           """
           You can update by running
-            
+
             mix archive.install hex nerves_bootstrap #{latest_version}
           """
         end
@@ -82,6 +82,15 @@ defmodule Nerves.Bootstrap do
       message,
       IO.ANSI.reset()
     ])
+  end
+
+  def mix_target do
+    if function_exported?(Mix, :target, 0) do
+      apply(Mix, :target, [])
+    else
+      (System.get_env("MIX_TARGET") || "host")
+      |> String.to_atom()
+    end
   end
 
   defp filter_pre_release(releases, %{pre: []}) do

--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -3,12 +3,10 @@ defmodule Nerves.Bootstrap.Aliases do
     with %{} <- Mix.ProjectStack.peek(),
          %{name: name, config: config, file: file} <- Mix.ProjectStack.pop(),
          nil <- Mix.ProjectStack.peek() do
-      target = System.get_env("MIX_TARGET")
-
       config =
         config
         |> host_config()
-        |> target_config(target)
+        |> target_config(Nerves.Bootstrap.mix_target())
 
       Mix.ProjectStack.push(name, config, file)
     else
@@ -22,7 +20,7 @@ defmodule Nerves.Bootstrap.Aliases do
     update_in(config, [:aliases], &add_host_aliases(&1))
   end
 
-  def target_config(config, target) when target in [nil, "host"], do: config
+  def target_config(config, :host), do: config
 
   def target_config(config, _target) do
     update_in(config, [:aliases], &add_target_aliases(&1))
@@ -48,8 +46,8 @@ defmodule Nerves.Bootstrap.Aliases do
   end
 
   def run(args) do
-    case System.get_env("MIX_TARGET") do
-      nil ->
+    case Nerves.Bootstrap.mix_target() do
+      :host ->
         Mix.Tasks.Run.run(args)
 
       target ->

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Nerves.Bootstrap.Mixfile do
     [
       app: :nerves_bootstrap,
       version: "1.3.4",
-      elixir: "~> 1.6",
+      elixir: "~> 1.8",
       aliases: aliases(),
       xref: [exclude: [Nerves.Env, Nerves.Artifact]],
       docs: [extras: ["README.md"], main: "readme"],

--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -59,4 +59,4 @@ config :nerves_init_gadget,
 # of this file so it overrides the configuration defined above.
 # Uncomment to use target specific configurations
 
-# import_config "#{Mix.Project.config[:target]}.exs"
+# import_config "#{Mix.target()}.exs"

--- a/templates/new/lib/app_name/application.ex
+++ b/templates/new/lib/app_name/application.ex
@@ -3,7 +3,7 @@ defmodule <%= app_module %>.Application do
   # for more information on OTP Applications
   @moduledoc false
 
-  @target Mix.Project.config()[:target]
+  @target Mix.target()
 
   use Application
 
@@ -15,7 +15,7 @@ defmodule <%= app_module %>.Application do
   end
 
   # List all child processes to be supervised
-  def children("host") do
+  def children(:host) do
     [
       # Starts a worker by calling: <%= app_module %>.Worker.start_link(arg)
       # {<%= app_module %>.Worker, arg},

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -21,12 +21,12 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "app: :#{@app_name}"
-        assert file =~ "defp system(\"rpi\"), do: [{:nerves_system_rpi, \"~> 1.5\""
-        assert file =~ "defp system(\"rpi0\"), do: [{:nerves_system_rpi0, \"~> 1.5\""
-        assert file =~ "defp system(\"rpi2\"), do: [{:nerves_system_rpi2, \"~> 1.5\""
-        assert file =~ "defp system(\"rpi3\"), do: [{:nerves_system_rpi3, \"~> 1.5\""
-        assert file =~ "defp system(\"bbb\"), do: [{:nerves_system_bbb, \"~> 2.0\""
-        assert file =~ "defp system(\"x86_64\"), do: [{:nerves_system_x86_64, \"~> 1.5\""
+        assert file =~ "{:nerves_system_rpi, \"~> 1.5\", runtime: false, targets: :rpi"
+        assert file =~ "{:nerves_system_rpi0, \"~> 1.5\", runtime: false, targets: :rpi0"
+        assert file =~ "{:nerves_system_rpi2, \"~> 1.5\", runtime: false, targets: :rpi2"
+        assert file =~ "{:nerves_system_rpi3, \"~> 1.5\", runtime: false, targets: :rpi3"
+        assert file =~ "{:nerves_system_bbb, \"~> 2.0\", runtime: false, targets: :bbb"
+        assert file =~ "{:nerves_system_x86_64, \"~> 1.5\", runtime: false, targets: :x86_64"
       end)
     end)
   end
@@ -39,8 +39,8 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "app: :#{@app_name}"
-        assert file =~ "defp system(\"rpi\"), do: [{:nerves_system_rpi, \"~> 1.5\""
-        refute file =~ "defp system(\"rpi0\"), do: [{:nerves_system_rpi0, \"~> 1.5\""
+        assert file =~ "{:nerves_system_rpi, \"~> 1.5\", runtime: false, targets: :rpi"
+        refute file =~ "{:nerves_system_rpi0, \"~> 1.5\", runtime: false, targets: :rpi0"
       end)
     end)
   end
@@ -53,9 +53,9 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "app: :#{@app_name}"
-        assert file =~ "defp system(\"rpi\"), do: [{:nerves_system_rpi, \"~> 1.5\""
-        assert file =~ "defp system(\"rpi3\"), do: [{:nerves_system_rpi3, \"~> 1.5\""
-        refute file =~ "defp system(\"rpi0\"), do: [{:nerves_system_rpi0, \"~> 1.5\""
+        assert file =~ "{:nerves_system_rpi, \"~> 1.5\", runtime: false, targets: :rpi"
+        assert file =~ "{:nerves_system_rpi3, \"~> 1.5\", runtime: false, targets: :rpi3"
+        refute file =~ "{:nerves_system_rpi0, \"~> 1.5\", runtime: false, targets: :rpi0"
       end)
     end)
   end


### PR DESCRIPTION
This adds support for `Mix.target()` available in Elixir 1.8. It also updates the new project generator to output Elixir 1.8 style code