### PR TITLE
Always build embedded

### DIFF
--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -14,7 +14,7 @@ defmodule <%= app_module %>.MixProject do
       config_path: "../../config/config.exs",
       lockfile: "../../mix.lock",<% end %>
       start_permanent: Mix.env() == :prod,
-      build_embedded: Mix.target() != :host,
+      build_embedded: true,
       aliases: [loadconfig: [&bootstrap/1]],
       deps: deps()
     ]


### PR DESCRIPTION
This causes everything to be built in the `_build` directory. No
symlinks back to the `deps` directory will be made. While this uses more
space and requires a copy, it saves confusion when build products get
mixed with source especially in the context of multiple targets.