### PR TITLE
Add nerves_init_gadget by default add --no-init-gadget to disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,10 @@ mix firmware.burn
 
 If you look at the generated `mix.exs`, you'll see how `MIX_TARGET` is used.
 
-The generated project is minimal and may be difficult to use especially if
-you're getting started with Nerves for the first time. The
-[nerves_init_gadget](https://hex.pm/packages/nerves_init_gadget) project
-simplifies initial configuration and is included by default.
-If you wish to omit `nerves_init_gadget` and its configurations from your generated
-project you can pass `--no-init-gadget`.
+The generated project includes [nerves_init_gadget](https://hex.pm/packages/nerves_init_gadget).
+This simplifies the initial configuration for many target platforms by including
+support for networking, firmware updates, and helpful utilities. If you want a
+minimal project that does not include `nerves_init_gadget`, pass `--no-init-gadget`:
 
 ```bash
 mix nerves.new my_new_nerves_project --no-init-gadget

--- a/README.md
+++ b/README.md
@@ -92,11 +92,12 @@ If you look at the generated `mix.exs`, you'll see how `MIX_TARGET` is used.
 The generated project is minimal and may be difficult to use especially if
 you're getting started with Nerves for the first time. The
 [nerves_init_gadget](https://hex.pm/packages/nerves_init_gadget) project
-simplifies initial configuration. To generate a skeleton project that uses it,
-run:
+simplifies initial configuration and is included by default.
+If you wish to omit `nerves_init_gadget` and its configurations from your generated
+project you can pass `--no-init-gadget`.
 
 ```bash
-mix nerves.new my_new_nerves_project --init-gadget
+mix nerves.new my_new_nerves_project --no-init-gadget
 ```
 
 ### mix local.nerves

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -76,8 +76,8 @@ defmodule Mix.Tasks.Nerves.New do
   A `--cookie` options can be given to set the Erlang distribution
   cookie in `vm.args`. This defaults to a randomly generated string.
 
-  Generate a project preloaded with `nerves_init_gadget` support by passing
-  `--init-gadget`.
+  Generate a project without `nerves_init_gadget` support by passing
+  `--no-init-gadget`.
 
   ## Examples
 
@@ -87,10 +87,6 @@ defmodule Mix.Tasks.Nerves.New do
 
       mix nerves.new blinky --module Blinky
 
-  Generate a project configured to use `nerves_init_gadget`
-
-      mix nerves.new blinky --init-gadget
-
   Generate a project that only supports Raspberry Pi 3
 
       mix nerves.new blinky --target rpi3
@@ -98,6 +94,10 @@ defmodule Mix.Tasks.Nerves.New do
   Generate a project that supports Raspberry Pi 3 and Raspberry Pi Zero
 
       mix nerves.new blinky --target rpi3 --target rpi0
+
+  Generate a project without `nerves_init_gadget`
+
+      mix nerves.new blinky --no-init-gadget
   """
 
   @switches [
@@ -154,7 +154,7 @@ defmodule Mix.Tasks.Nerves.New do
 
     nerves_path = nerves_path(path, Keyword.get(opts, :dev, false))
     in_umbrella? = in_umbrella?(path)
-    init_gadget? = opts[:init_gadget] || false
+    init_gadget? = Keyword.get(opts, :init_gadget, true)
 
     targets = Keyword.get_values(opts, :target)
     default_targets = Keyword.keys(@targets)

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -56,12 +56,12 @@ defmodule Mix.Tasks.Nerves.New do
   end
 
   @moduledoc """
-  Creates a new Nerves project. It expects the path of the project as argument.
+  Creates a new Nerves project
 
       mix nerves.new PATH [--module MODULE] [--app APP] [--target TARGET] [--cookie STRING]
 
-  A project at the given PATH will be created. The application name and module
-  name will be retrieved from the path, unless `--module` or `--app` is given.
+  The project will be created at PATH. The application name and module name
+  will be inferred from PATH unless `--module` or `--app` is given.
 
   An `--app` option can be given in order to name the OTP application for the
   project.

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -145,17 +145,32 @@ defmodule Nerves.NewTest do
     end)
   end
 
-  test "new project init gadget", context do
+  test "new project sets includes nerves_init_gadget", context do
     in_tmp(context.test, fn ->
-      Mix.Tasks.Nerves.New.run([@app_name, "--init-gadget"])
+      Mix.Tasks.Nerves.New.run([@app_name])
 
       assert_file("#{@app_name}/mix.exs", fn file ->
-        assert file =~ ~r"nerves_init_gadget"
+        assert file =~ ~r/:nerves_init_gadget/
       end)
 
       assert_file("#{@app_name}/config/config.exs", fn file ->
         assert file =~ ~r"nerves_init_gadget"
         assert file =~ ~r"nerves_firmware_ssh"
+      end)
+    end)
+  end
+
+  test "new project without init gadget", context do
+    in_tmp(context.test, fn ->
+      Mix.Tasks.Nerves.New.run([@app_name, "--no-init-gadget"])
+
+      assert_file("#{@app_name}/mix.exs", fn file ->
+        refute file =~ ~r"nerves_init_gadget"
+      end)
+
+      assert_file("#{@app_name}/config/config.exs", fn file ->
+        refute file =~ ~r"nerves_init_gadget"
+        refute file =~ ~r"nerves_firmware_ssh"
       end)
     end)
   end


### PR DESCRIPTION
Adding `nerves_init_gadget` by default seems pretty safe and useful. Before this PR, you would have to opt in to adding `nerves_init_gadget` by calling

```bash
mix nerves.new my_app --init-gadget
```

After this PR you will be able to do the inverse and opt out by running.

```bash
mix nerves.new my_app --no-init-gadget
```