### PR TITLE
Support distillery as an optional dependency

### DIFF
--- a/lib/mix/tasks/nerves/env.ex
+++ b/lib/mix/tasks/nerves/env.ex
@@ -24,6 +24,11 @@ defmodule Mix.Tasks.Nerves.Env do
 
     unless Code.ensure_compiled?(Nerves.Env) do
       Mix.Tasks.Deps.Loadpaths.run(["--no-compile"])
+
+      if distillery?() do
+        Mix.Tasks.Deps.Compile.run(["distillery", "--include-children"])
+      end
+
       Mix.Tasks.Deps.Compile.run(["nerves", "--include-children"])
     end
 
@@ -51,5 +56,11 @@ defmodule Mix.Tasks.Nerves.Env do
       Type:        #{pkg.type}
       BuildRunner: #{inspect(pkg.build_runner)}
     """)
+  end
+
+  defp distillery?() do
+    Mix.Project.deps_paths()
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.member?(:distillery)
   end
 end


### PR DESCRIPTION
With the addition of Elixir 1.9 releases, the `distillery` dependency become optional. This means, that existing system will need to explicitly add it to their dependencies to continue to use the new tools. This PR ensures that if distillery is present when bootstraping mix that it and its children are compiled prior to compiling `nerves`. 