### PR TITLE
Update new project generator for Elixir 1.9+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,9 @@ version: 2
 jobs:
   build:
     docker:
-      - image: erlang:21.3.8
+      - image: erlang:22.0.2
         environment:
-          ELIXIR_VERSION: 1.8.2-otp-21
+          ELIXIR_VERSION: 1.9.0-otp-22
           LC_ALL: C.UTF-8
     working_directory: ~/repo
     environment:

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -9,16 +9,15 @@ defmodule Mix.Tasks.Nerves.New do
                             v = Version.parse!(@bootstrap_vsn)
                             "#{v.major}.#{v.minor}"
                           )
-  @nerves_vsn "1.4.5"
+  @nerves_vsn "1.5.0"
   @nerves_dep ~s[{:nerves, "~> #{@nerves_vsn}", runtime: false}]
-  @distillery_vsn "2.0"
-  @shoehorn_vsn "0.4"
+  @shoehorn_vsn "0.6"
   @runtime_vsn "0.6"
   @ring_logger_vsn "0.6"
   @init_gadget_vsn "0.4"
   @toolshed_vsn "0.2"
 
-  @elixir_vsn "~> 1.8"
+  @elixir_vsn "~> 1.9"
   @shortdoc "Creates a new Nerves application"
 
   @targets [
@@ -33,11 +32,12 @@ defmodule Mix.Tasks.Nerves.New do
 
   @new [
     {:eex, "new/config/config.exs", "config/config.exs"},
+    {:eex, "new/config/target.exs", "config/target.exs"},
     {:eex, "new/lib/app_name.ex", "lib/app_name.ex"},
     {:eex, "new/lib/app_name/application.ex", "lib/app_name/application.ex"},
     {:eex, "new/test/test_helper.exs", "test/test_helper.exs"},
     {:eex, "new/test/app_name_test.exs", "test/app_name_test.exs"},
-    {:eex, "new/rel/vm.args", "rel/vm.args"},
+    {:text, "new/rel/vm.args.eex", "rel/vm.args.eex"},
     {:eex, "new/rootfs_overlay/etc/iex.exs", "rootfs_overlay/etc/iex.exs"},
     {:text, "new/.gitignore", ".gitignore"},
     {:text, "new/.formatter.exs", ".formatter.exs"},
@@ -187,7 +187,6 @@ defmodule Mix.Tasks.Nerves.New do
       app_name: app,
       app_module: mod,
       bootstrap_vsn: @bootstrap_vsn_no_patch,
-      distillery_vsn: @distillery_vsn,
       shoehorn_vsn: @shoehorn_vsn,
       runtime_vsn: @runtime_vsn,
       ring_logger_vsn: @ring_logger_vsn,
@@ -209,10 +208,9 @@ defmodule Mix.Tasks.Nerves.New do
       extra =
         if install? && Code.ensure_loaded?(Hex) do
           cmd("mix deps.get")
-          cmd("mix nerves.release.init")
           []
         else
-          ["  $ mix deps.get", "  $ mix nerves.release.init"]
+          ["  $ mix deps.get"]
         end
 
       print_mix_info(path, extra)

--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -5,6 +5,8 @@
 # is restricted to this project.
 use Mix.Config
 
+config :<%= app_name %>, target: Mix.target()
+
 # Customize non-Elixir parts of the firmware. See
 # https://hexdocs.pm/nerves/advanced-configuration.html for details.
 
@@ -22,47 +24,8 @@ config :shoehorn,
 # See https://hexdocs.pm/ring_logger/readme.html for more information on
 # configuring ring_logger.
 
-config :logger, backends: [RingLogger]<%= if init_gadget? do %>
+config :logger, backends: [RingLogger]
 
-# Authorize the device to receive firmware using your public key.
-# See https://hexdocs.pm/nerves_firmware_ssh/readme.html for more information
-# on configuring nerves_firmware_ssh.
-
-keys =
-  [
-    Path.join([System.user_home!(), ".ssh", "id_rsa.pub"]),
-    Path.join([System.user_home!(), ".ssh", "id_ecdsa.pub"]),
-    Path.join([System.user_home!(), ".ssh", "id_ed25519.pub"])
-  ]
-  |> Enum.filter(&File.exists?/1)
-
-if keys == [],
-  do:
-    Mix.raise("""
-    No SSH public keys found in ~/.ssh. An ssh authorized key is needed to
-    log into the Nerves device and update firmware on it using ssh.
-    See your project's config.exs for this error message.
-    """)
-
-config :nerves_firmware_ssh,
-  authorized_keys: Enum.map(keys, &File.read!/1)
-
-# Configure nerves_init_gadget.
-# See https://hexdocs.pm/nerves_init_gadget/readme.html for more information.
-
-# Setting the node_name will enable Erlang Distribution.
-# Only enable this for prod if you understand the risks.
-node_name = if Mix.env() != :prod, do: "<%= app_name %>"
-
-config :nerves_init_gadget,
-  ifname: "usb0",
-  address_method: :dhcpd,
-  mdns_domain: "nerves.local",
-  node_name: node_name,
-  node_host: :mdns_domain<% end %>
-
-# Import target specific config. This must remain at the bottom
-# of this file so it overrides the configuration defined above.
-# Uncomment to use target specific configurations
-
-# import_config "#{Mix.target()}.exs"
+if Mix.target() != :host do
+  import_config "target.exs"
+end

--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -1,0 +1,44 @@
+use Mix.Config<%= if init_gadget? do %>
+
+# Authorize the device to receive firmware using your public key.
+# See https://hexdocs.pm/nerves_firmware_ssh/readme.html for more information
+# on configuring nerves_firmware_ssh.
+
+keys =
+  [
+    Path.join([System.user_home!(), ".ssh", "id_rsa.pub"]),
+    Path.join([System.user_home!(), ".ssh", "id_ecdsa.pub"]),
+    Path.join([System.user_home!(), ".ssh", "id_ed25519.pub"])
+  ]
+  |> Enum.filter(&File.exists?/1)
+
+if keys == [],
+  do:
+    Mix.raise("""
+    No SSH public keys found in ~/.ssh. An ssh authorized key is needed to
+    log into the Nerves device and update firmware on it using ssh.
+    See your project's config.exs for this error message.
+    """)
+
+config :nerves_firmware_ssh,
+  authorized_keys: Enum.map(keys, &File.read!/1)
+
+# Configure nerves_init_gadget.
+# See https://hexdocs.pm/nerves_init_gadget/readme.html for more information.
+
+# Setting the node_name will enable Erlang Distribution.
+# Only enable this for prod if you understand the risks.
+node_name = if Mix.env() != :prod, do: "<%= app_name %>"
+
+config :nerves_init_gadget,
+  ifname: "usb0",
+  address_method: :dhcpd,
+  mdns_domain: "nerves.local",
+  node_name: node_name,
+  node_host: :mdns_domain<% end %>
+
+# Import target specific config. This must remain at the bottom
+# of this file so it overrides the configuration defined above.
+# Uncomment to use target specific configurations
+
+# import_config "#{Mix.target()}.exs"

--- a/templates/new/lib/app_name/application.ex
+++ b/templates/new/lib/app_name/application.ex
@@ -3,20 +3,26 @@ defmodule <%= app_module %>.Application do
   # for more information on OTP Applications
   @moduledoc false
 
-  @target Mix.target()
-
   use Application
 
   def start(_type, _args) do
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: <%= app_module %>.Supervisor]
-    Supervisor.start_link(children(@target), opts)
+    children =
+      [
+        # Children for all targets
+        # Starts a worker by calling: <%= app_module %>.Worker.start_link(arg)
+        # {<%= app_module %>.Worker, arg},
+      ] ++ children(target())
+
+    Supervisor.start_link(children, opts)
   end
 
   # List all child processes to be supervised
   def children(:host) do
     [
+      # Children that only run on the host
       # Starts a worker by calling: <%= app_module %>.Worker.start_link(arg)
       # {<%= app_module %>.Worker, arg},
     ]
@@ -24,8 +30,13 @@ defmodule <%= app_module %>.Application do
 
   def children(_target) do
     [
+      # Children for all targets except host
       # Starts a worker by calling: <%= app_module %>.Worker.start_link(arg)
       # {<%= app_module %>.Worker, arg},
     ]
+  end
+
+  def target() do
+    Application.get_env(:<%= app_name %>, :target)
   end
 end

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -1,12 +1,14 @@
 defmodule <%= app_module %>.MixProject do
   use Mix.Project
 
+  @app :<%= app_name %>
+  @version "0.1.0"
   @all_targets <%= inspect(Enum.map(targets, &elem(&1, 0))) %>
 
   def project do
     [
-      app: :<%= app_name %>,
-      version: "0.1.0",
+      app: @app,
+      version: @version,
       elixir: "<%= elixir_req %>",
       archives: [nerves_bootstrap: "~> <%= bootstrap_vsn %>"],<%= if in_umbrella do %>
       deps_path: "../../deps",
@@ -16,7 +18,9 @@ defmodule <%= app_module %>.MixProject do
       start_permanent: Mix.env() == :prod,
       build_embedded: true,
       aliases: [loadconfig: [&bootstrap/1]],
-      deps: deps()
+      deps: deps(),
+      releases: [{@app, release()}],
+      preferred_cli_target: [run: :host, test: :host]
     ]
   end
 
@@ -40,7 +44,6 @@ defmodule <%= app_module %>.MixProject do
     [
       # Dependencies for all targets
       <%= nerves_dep %>,
-      {:distillery, "~> <%= distillery_vsn %>"},
       {:shoehorn, "~> <%= shoehorn_vsn %>"},
       {:ring_logger, "~> <%= ring_logger_vsn %>"},
       {:toolshed, "~> <%= toolshed_vsn %>"},
@@ -53,6 +56,15 @@ defmodule <%= app_module %>.MixProject do
       <%= for {target, vsn} <- targets do %>
       {:<%= "nerves_system_#{target}" %>, "~> <%= vsn %>", runtime: false, targets: :<%= target %>},
       <% end %>
+    ]
+  end
+
+  def release do
+    [
+      overwrite: true,
+      cookie: "#{@app}_cookie",
+      include_erts: &Nerves.Release.erts/0,
+      steps: [&Nerves.Release.init/1, :assemble]
     ]
   end
 end

--- a/templates/new/rel/vm.args.eex
+++ b/templates/new/rel/vm.args.eex
@@ -4,8 +4,7 @@
 ##  The cookie needs to be configured prior to vm boot for
 ##  for read only filesystem.
 
-# -name <%= app_name %>@0.0.0.0
--setcookie <%= cookie %>
+-setcookie <%= @release.options[:cookie] %>
 
 ## Use Ctrl-C to interrupt the current shell rather than invoking the emulator's
 ## break handler and possibly exiting the VM.

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -20,7 +20,7 @@ defmodule Nerves.NewTest do
       assert_file("#{@app_name}/README.md")
 
       assert_file("#{@app_name}/mix.exs", fn file ->
-        assert file =~ "app: :#{@app_name}"
+        assert file =~ "@app :#{@app_name}"
         assert file =~ "{:nerves_system_rpi, \"~> 1.6\", runtime: false, targets: :rpi"
         assert file =~ "{:nerves_system_rpi0, \"~> 1.6\", runtime: false, targets: :rpi0"
         assert file =~ "{:nerves_system_rpi2, \"~> 1.6\", runtime: false, targets: :rpi2"
@@ -39,7 +39,7 @@ defmodule Nerves.NewTest do
       assert_file("#{@app_name}/README.md")
 
       assert_file("#{@app_name}/mix.exs", fn file ->
-        assert file =~ "app: :#{@app_name}"
+        assert file =~ "@app :#{@app_name}"
         assert file =~ "{:nerves_system_rpi, \"~> 1.6\", runtime: false, targets: :rpi"
         refute file =~ "{:nerves_system_rpi0, \"~> 1.6\", runtime: false, targets: :rpi0"
       end)
@@ -53,7 +53,7 @@ defmodule Nerves.NewTest do
       assert_file("#{@app_name}/README.md")
 
       assert_file("#{@app_name}/mix.exs", fn file ->
-        assert file =~ "app: :#{@app_name}"
+        assert file =~ "@app :#{@app_name}"
         assert file =~ "{:nerves_system_rpi, \"~> 1.6\", runtime: false, targets: :rpi"
         assert file =~ "{:nerves_system_rpi3, \"~> 1.6\", runtime: false, targets: :rpi3"
         refute file =~ "{:nerves_system_rpi0, \"~> 1.6\", runtime: false, targets: :rpi0"
@@ -61,22 +61,12 @@ defmodule Nerves.NewTest do
     end)
   end
 
-  test "new project defined cookie set", context do
-    in_tmp(context.test, fn ->
-      Mix.Tasks.Nerves.New.run([@app_name, "--cookie", "12345"])
-
-      assert_file("#{@app_name}/rel/vm.args", fn file ->
-        assert file =~ "-setcookie 12345"
-      end)
-    end)
-  end
-
-  test "new project default cookie set", context do
+  test "new project cookie set", context do
     in_tmp(context.test, fn ->
       Mix.Tasks.Nerves.New.run([@app_name])
 
-      assert_file("#{@app_name}/rel/vm.args", fn file ->
-        assert file =~ ~r/.*-setcookie [a-zA-Z0-9]{64}\n|\r|\n\r/s
+      assert_file("#{@app_name}/mix.exs", fn file ->
+        assert file =~ "cookie: \"\#{@app}_cookie\""
       end)
     end)
   end
@@ -85,7 +75,7 @@ defmodule Nerves.NewTest do
     in_tmp(context.test, fn ->
       Mix.Tasks.Nerves.New.run([@app_name])
 
-      assert_file("#{@app_name}/rel/vm.args", fn file ->
+      assert_file("#{@app_name}/rel/vm.args.eex", fn file ->
         assert file =~ "-heart -env HEART_BEAT_TIMEOUT"
       end)
     end)
@@ -95,7 +85,7 @@ defmodule Nerves.NewTest do
     in_tmp(context.test, fn ->
       Mix.Tasks.Nerves.New.run([@app_name])
 
-      assert_file("#{@app_name}/rel/vm.args", fn file ->
+      assert_file("#{@app_name}/rel/vm.args.eex", fn file ->
         assert file =~ "-mode embedded"
       end)
     end)
@@ -153,7 +143,7 @@ defmodule Nerves.NewTest do
         assert file =~ ~r/:nerves_init_gadget/
       end)
 
-      assert_file("#{@app_name}/config/config.exs", fn file ->
+      assert_file("#{@app_name}/config/target.exs", fn file ->
         assert file =~ ~r"nerves_init_gadget"
         assert file =~ ~r"nerves_firmware_ssh"
       end)
@@ -171,16 +161,6 @@ defmodule Nerves.NewTest do
       assert_file("#{@app_name}/config/config.exs", fn file ->
         refute file =~ ~r"nerves_init_gadget"
         refute file =~ ~r"nerves_firmware_ssh"
-      end)
-    end)
-  end
-
-  test "new project includes distillery", context do
-    in_tmp(context.test, fn ->
-      Mix.Tasks.Nerves.New.run([@app_name])
-
-      assert_file("#{@app_name}/mix.exs", fn file ->
-        assert file =~ ~r/:distillery/
       end)
     end)
   end


### PR DESCRIPTION
A couple things that have changed in the new project generator to embrace updates from Elixir 1.9.

**preferred_cli_target**
The `Mix.Project` config now supports configuring the target that cli commands are to run under. This allows developers to `export MIX_TARGET={something}` and still have certain mix tasks to run under the `:host` target.

For example:
```
preferred_cli_target: [run: :host, test: :host]
```

in this example, when the user runs `mix test`, `mix run`, or just `mix` the tasks will execute under the `:host` target environment regardless of what `MIX_TARGET` equals.

**target.exs**
Mix commands executed on the host will load `config.exs` and throw warnings when config values exist for unloaded applications. Since `mix test` executes under the `:host` target, the target specific applications are not loaded. The target specific configurations have been moved to `target.exs` and are imported if `Mix.target() != :host`.

**application.ex**
There are two changes here that are intended to alleviate confusion. 

First, the target is no longer pulled from `Mix.target()` in a module tag, calls to Mix have been moved to `config.exs`. In conjunction, a new `target/0` function is defined so the target information can be made accessible to other application modules.

Second, the main application supervisor's children list includes a place for children for all targets in addition to target specific children. This aligns the option combinations with the dependency combinations in the mix file (all targets / all targets except host). I've found myself adding this section in over the last few month for new projects.


**releases**
Support for Elixir 1.9 releases has been added. The release is now configured in the `Mix.Project` config under the key `releases`.

Here are the defaults:
```
[
  overwrite: true,
  cookie: "#{@app}_cookie",
  include_erts: &Nerves.Release.erts/0,
  steps: [&Nerves.Release.init/1, :assemble]
]
```
The important change here is that we are now setting the distribution cookie to `app_name`_cookie. The distribution cookie isn't actually secure so randomly generating is misleading and also makes it more difficult to use for dev and test. By setting it to a known value that is scoped under the application name, we can make it easier and more reliable to use distribution based debug tools from the command line.

The vm.args file moved.
`rel/vm.args` is now expected to be `rel/vm.args.eex` and is processed when calling `mix firmware`.

The best part of all is that `nerves` now has 0 direct dependencies! 🎉