### PR TITLE
Allow to set cookie with `mix nerves.new`

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -182,7 +182,7 @@ defmodule Mix.Tasks.Nerves.New do
       end)
 
     targets = if targets == [], do: @targets, else: targets
-    cookie = opts[:cookie] || random_string(64)
+    cookie = opts[:cookie]
 
     binding = [
       app_name: app,
@@ -375,11 +375,5 @@ defmodule Mix.Tasks.Nerves.New do
     catch
       _, _ -> false
     end
-  end
-
-  defp random_string(length) do
-    :crypto.strong_rand_bytes(length)
-    |> Base.encode32(case: :lower, padding: false)
-    |> binary_part(0, length)
   end
 end

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -109,6 +109,7 @@ defmodule Mix.Tasks.Nerves.New do
     init_gadget: :boolean
   ]
 
+  @impl Mix.Task
   def run([version]) when version in ~w(-v --version) do
     Mix.shell().info("Nerves Bootstrap v#{@bootstrap_vsn}")
   end

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -62,7 +62,7 @@ defmodule <%= app_module %>.MixProject do
   def release do
     [
       overwrite: true,
-      cookie: "#{@app}_cookie",
+      cookie: "<%= cookie %>",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble]
     ]

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -62,7 +62,7 @@ defmodule <%= app_module %>.MixProject do
   def release do
     [
       overwrite: true,
-      cookie: "<%= cookie %>",
+      cookie: <%= if cookie do %>"<%= cookie %>"<% else %>"#{@app}_cookie"<% end %>,
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble]
     ]

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -63,10 +63,21 @@ defmodule Nerves.NewTest do
 
   test "new project cookie set", context do
     in_tmp(context.test, fn ->
+      Mix.Tasks.Nerves.New.run([@app_name, "--cookie", "foo"])
+
+      assert_file("#{@app_name}/mix.exs", fn file ->
+        assert file =~ ~s{cookie: "foo"}
+      end)
+    end)
+  end
+
+  test "cookie by default is a random string of 64 chars", context do
+    in_tmp(context.test, fn ->
       Mix.Tasks.Nerves.New.run([@app_name])
 
       assert_file("#{@app_name}/mix.exs", fn file ->
-        assert file =~ "cookie: \"\#{@app}_cookie\""
+        [_, capture] = Regex.run(~r/cookie: "([^"]+)/, file)
+        assert String.length(capture) == 64
       end)
     end)
   end

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -71,13 +71,12 @@ defmodule Nerves.NewTest do
     end)
   end
 
-  test "cookie by default is a random string of 64 chars", context do
+  test "new project provides a default cookie", context do
     in_tmp(context.test, fn ->
       Mix.Tasks.Nerves.New.run([@app_name])
 
       assert_file("#{@app_name}/mix.exs", fn file ->
-        [_, capture] = Regex.run(~r/cookie: "([^"]+)/, file)
-        assert String.length(capture) == 64
+        assert file =~ "cookie: \"\#{@app}_cookie\""
       end)
     end)
   end


### PR DESCRIPTION
Currently the option `--cookie STRING` is ignored by `mix nerves.new`, this PR
should fix this scenario.

If the `--cookie` option is omitted, a random string of 64 chars will be used
instead.