### PR TITLE
Prevent reserved names from being used to create apps

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -47,6 +47,8 @@ defmodule Mix.Tasks.Nerves.New do
     {:keep, "new/rel", "rel"}
   ]
 
+  @reserved_names ~w[nerves]
+
   # Embed all defined templates
   root = Path.expand("../../../../templates", __DIR__)
 
@@ -151,6 +153,9 @@ defmodule Mix.Tasks.Nerves.New do
         run(app, mod, path, opts)
     end
   end
+
+  defp run(app, _mod, _path, _opts) when app in @reserved_names,
+    do: Mix.raise("New projects cannot be named '#{app}'")
 
   defp run(app, mod, path, opts) do
     System.delete_env("MIX_TARGET")

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -175,4 +175,12 @@ defmodule Nerves.NewTest do
       end)
     end)
   end
+
+  test "new projects cannot use reserved names", context do
+    in_tmp(context.test, fn ->
+      assert_raise(Mix.Error, "New projects cannot be named 'nerves'", fn ->
+        Mix.Tasks.Nerves.New.run(["nerves"])
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
This prevents apps from being named "nerves", but I also wrote it in a way to easily add more reserved names later (For instance in Hex we have about a half-dozen.)

Fixes #119 