### PR TITLE
Replace use Mix.Config with import Config

### DIFF
--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -3,7 +3,7 @@
 #
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
-use Mix.Config
+import Config
 
 config :<%= app_name %>, target: Mix.target()
 

--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -1,4 +1,4 @@
-use Mix.Config<%= if init_gadget? do %>
+import Config<%= if init_gadget? do %>
 
 # Authorize the device to receive firmware using your public key.
 # See https://hexdocs.pm/nerves_firmware_ssh/readme.html for more information


### PR DESCRIPTION
Mix.Config has been deprecated in Elixir 1.9. Update to the new import Config