### PR TITLE
Set source_date_epoch to utc now in new projects

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -109,7 +109,8 @@ defmodule Mix.Tasks.Nerves.New do
     module: :string,
     target: :keep,
     cookie: :string,
-    init_gadget: :boolean
+    init_gadget: :boolean,
+    source_date_epoch: :integer
   ]
 
   @impl Mix.Task
@@ -189,6 +190,7 @@ defmodule Mix.Tasks.Nerves.New do
 
     targets = if targets == [], do: @targets, else: targets
     cookie = opts[:cookie]
+    source_date_epoch = Keyword.get(opts, :source_date_epoch, generate_source_date_epoch())
 
     binding = [
       app_name: app,
@@ -204,7 +206,8 @@ defmodule Mix.Tasks.Nerves.New do
       init_gadget_vsn: @init_gadget_vsn,
       toolshed_vsn: @toolshed_vsn,
       targets: targets,
-      cookie: cookie
+      cookie: cookie,
+      source_date_epoch: source_date_epoch
     ]
 
     copy_from(path, binding, @new)
@@ -381,5 +384,9 @@ defmodule Mix.Tasks.Nerves.New do
     catch
       _, _ -> false
     end
+  end
+
+  defp generate_source_date_epoch() do
+    DateTime.utc_now() |> DateTime.to_unix()
   end
 end

--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -12,6 +12,11 @@ config :<%= app_name %>, target: Mix.target()
 
 config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 
+# Set the SOURCE_DATE_EPOCH date for reproducible builds.
+# See https://reproducible-builds.org/docs/source-date-epoch/ for more information
+
+config :nerves, source_date_epoch: "<%= source_date_epoch %>"
+
 # Use shoehorn to start the main application. See the shoehorn
 # docs for separating out critical OTP applications such as those
 # involved with firmware updates.

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -183,4 +183,24 @@ defmodule Nerves.NewTest do
       end)
     end)
   end
+
+  test "new project sets source_date_epoch time", context do
+    in_tmp(context.test, fn ->
+      Mix.Tasks.Nerves.New.run([@app_name, "--source-date-epoch", "1234"])
+
+      assert_file("#{@app_name}/config/config.exs", fn file ->
+        assert file =~ ~r/source_date_epoch: "1234"/
+      end)
+    end)
+  end
+
+  test "new project generates source_date_epoch time", context do
+    in_tmp(context.test, fn ->
+      Mix.Tasks.Nerves.New.run([@app_name])
+
+      assert_file("#{@app_name}/config/config.exs", fn file ->
+        assert file =~ ~r/source_date_epoch: /
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
This will add the following config to the `config/config.exs` file:

```elixir
config :nerves, source_date_epoch: "1574108765"
```