### PR TITLE
Optionaly use nerves_pack instead of init_gadget

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ minimal project that does not include `nerves_init_gadget`, pass `--no-init-gadg
 mix nerves.new my_new_nerves_project --no-init-gadget
 ```
 
+To use `nerves_pack` instead of `nerves_init_gadget` you can pass `--nerves-pack`.
+See [nerves_pack](https://hex.pm/packages/nerves_pack) for more information.
+
+```bash
+mix nerves.new my_new_nerves_project --nerves-pack
+```
+
 ### mix local.nerves
 
 This task checks [hex.pm](https://hex.pm/packages/nerves_bootstrap) for updates

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Nerves.New do
   @shoehorn_vsn "0.6"
   @runtime_vsn "0.6"
   @ring_logger_vsn "0.6"
+  @nerves_pack_vsn "0.2"
   @init_gadget_vsn "0.4"
   @toolshed_vsn "0.2"
 
@@ -83,6 +84,9 @@ defmodule Mix.Tasks.Nerves.New do
   Generate a project without `nerves_init_gadget` support by passing
   `--no-init-gadget`.
 
+  Generate a project with `nerves_pack` instead of `nerves_init_gadget` by passing
+  `--nerves-pack`.
+
   ## Examples
 
       mix nerves.new blinky
@@ -102,6 +106,10 @@ defmodule Mix.Tasks.Nerves.New do
   Generate a project without `nerves_init_gadget`
 
       mix nerves.new blinky --no-init-gadget
+
+  Generate a project with `nerves_pack`
+
+      mix nerves.new blinky --nerves-pack
   """
 
   @switches [
@@ -110,6 +118,7 @@ defmodule Mix.Tasks.Nerves.New do
     target: :keep,
     cookie: :string,
     init_gadget: :boolean,
+    nerves_pack: :boolean,
     source_date_epoch: :integer
   ]
 
@@ -163,7 +172,13 @@ defmodule Mix.Tasks.Nerves.New do
 
     nerves_path = nerves_path(path, Keyword.get(opts, :dev, false))
     in_umbrella? = in_umbrella?(path)
-    init_gadget? = Keyword.get(opts, :init_gadget, true)
+
+    {nerves_pack?, init_gadget?} =
+      if Keyword.get(opts, :nerves_pack) do
+        {true, false}
+      else
+        {false, Keyword.get(opts, :init_gadget, true)}
+      end
 
     targets = Keyword.get_values(opts, :target)
     default_targets = Keyword.keys(@targets)
@@ -202,6 +217,8 @@ defmodule Mix.Tasks.Nerves.New do
       elixir_req: @elixir_vsn,
       nerves_dep: nerves_dep(nerves_path),
       in_umbrella: in_umbrella?,
+      nerves_pack?: nerves_pack?,
+      nerves_pack_vsn: @nerves_pack_vsn,
       init_gadget?: init_gadget?,
       init_gadget_vsn: @init_gadget_vsn,
       toolshed_vsn: @toolshed_vsn,

--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -22,7 +22,7 @@ config :nerves, source_date_epoch: "<%= source_date_epoch %>"
 # involved with firmware updates.
 
 config :shoehorn,
-  init: [:nerves_runtime<%= if init_gadget? do %>, :nerves_init_gadget<% end %>],
+  init: [:nerves_runtime<%= if init_gadget? do %>, :nerves_init_gadget<% end %><%= if nerves_pack? do %>, :nerves_pack<% end %>],
   app: Mix.Project.config()[:app]
 
 # Use Ringlogger as the logger backend and remove :console.

--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -1,4 +1,4 @@
-import Config<%= if init_gadget? do %>
+import Config<%= if init_gadget? or nerves_pack? do %>
 
 # Authorize the device to receive firmware using your public key.
 # See https://hexdocs.pm/nerves_firmware_ssh/readme.html for more information
@@ -21,7 +21,7 @@ if keys == [],
     """)
 
 config :nerves_firmware_ssh,
-  authorized_keys: Enum.map(keys, &File.read!/1)
+  authorized_keys: Enum.map(keys, &File.read!/1)<% end %><%= if init_gadget? do %>
 
 # Configure nerves_init_gadget.
 # See https://hexdocs.pm/nerves_init_gadget/readme.html for more information.
@@ -35,8 +35,54 @@ config :nerves_init_gadget,
   address_method: :dhcpd,
   mdns_domain: "nerves.local",
   node_name: node_name,
-  node_host: :mdns_domain<% end %>
+  node_host: :mdns_domain<% end %><%= if nerves_pack? do %>
 
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"usb0", %{type: VintageNetDirect}},
+    {"eth0",
+      %{
+        type: VintageNetEthernet,
+        ipv4: %{ method: :dhcp }
+      }},
+    {"wlan0", %{ type: VintageNetWiFi }}
+  ]
+
+config :mdns_lite,
+  # The `host` key specifies what hostnames mdns_lite advertises.  `:hostname`
+  # advertises the device's hostname.local. For the official Nerves systems, this
+  # is "nerves-<4 digit serial#>.local".  mdns_lite also advertises
+  # "nerves.local" for convenience. If more than one Nerves device is on the
+  # network, delete "nerves" from the list.
+
+  host: [:hostname, "nerves"],
+  ttl: 120,
+
+  # Advertise the following services over mDNS.
+  services: [
+    %{
+      name: "SSH Remote Login Protocol",
+      protocol: "ssh",
+      transport: "tcp",
+      port: 22
+    },
+    %{
+      name: "Secure File Transfer Protocol over SSH",
+      protocol: "sftp-ssh",
+      transport: "tcp",
+      port: 22
+    },
+    %{
+      name: "Erlang Port Mapper Daemon",
+      protocol: "epmd",
+      transport: "tcp",
+      port: 4369
+    }
+  ]<% end %>
+  
 # Import target specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 # Uncomment to use target specific configurations

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -50,7 +50,8 @@ defmodule <%= app_module %>.MixProject do
 
       # Dependencies for all targets except :host
       {:nerves_runtime, "~> <%= runtime_vsn %>", targets: @all_targets},<%= if init_gadget? do %>
-      {:nerves_init_gadget, "~> <%= init_gadget_vsn %>", targets: @all_targets},<% end %>
+      {:nerves_init_gadget, "~> <%= init_gadget_vsn %>", targets: @all_targets},<% end %><%= if nerves_pack? do %>
+      {:nerves_pack, "~> <%= nerves_pack_vsn %>", targets: @all_targets},<% end %>
 
       # Dependencies for specific targets
       <%= for {target, vsn} <- targets do %>

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -161,6 +161,24 @@ defmodule Nerves.NewTest do
     end)
   end
 
+  test "new project with nerves_pack", context do
+    in_tmp(context.test, fn ->
+      Mix.Tasks.Nerves.New.run([@app_name, "--nerves-pack"])
+
+      assert_file("#{@app_name}/mix.exs", fn file ->
+        assert file =~ ~r/:nerves_pack/
+        refute file =~ ~r/:nerves_init_gadget/
+      end)
+
+      assert_file("#{@app_name}/config/target.exs", fn file ->
+        refute file =~ ~r"nerves_init_gadget"
+        assert file =~ ~r"nerves_firmware_ssh"
+        assert file =~ ~r"vintage_net"
+        assert file =~ ~r"mdns_lite"
+      end)
+    end)
+  end
+
   test "new project without init gadget", context do
     in_tmp(context.test, fn ->
       Mix.Tasks.Nerves.New.run([@app_name, "--no-init-gadget"])


### PR DESCRIPTION
This updates the new project generator to allow passing `--nerves-pack` to use `:nerves_pack` instead of `:nerves_init_gadget`. This will allow us to make a release and gather feedback while we get the documentation and examples updated.