### PR TITLE
Don't use system_registry with nerves_runtime

### DIFF
--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -83,6 +83,12 @@ config :mdns_lite,
     }
   ]<% end %>
 
+# Nerves Runtime can enumerate hardware devices and send notifications via
+# SystemRegistry. This slows down startup and not many programs make use of
+# this feature.
+
+config :nerves_runtime, :kernel, use_system_registry: false
+
 # Use shoehorn to start the main application. See the shoehorn
 # docs for separating out critical OTP applications such as those
 # involved with firmware updates.


### PR DESCRIPTION
This feature isn't well-used and it currently adds about 6 seconds to
the boot time (about 20% improvement with it off - power to ping on a
RPi Zero). Users who need it can enable it. Most users will get to enjoy
slightly faster reboots.