### PR TITLE
Move shoehorn config to target.exs

### DIFF
--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -17,14 +17,6 @@ config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 
 config :nerves, source_date_epoch: "<%= source_date_epoch %>"
 
-# Use shoehorn to start the main application. See the shoehorn
-# docs for separating out critical OTP applications such as those
-# involved with firmware updates.
-
-config :shoehorn,
-  init: [:nerves_runtime<%= if init_gadget? do %>, :nerves_init_gadget<% end %><%= if nerves_pack? do %>, :nerves_pack<% end %>],
-  app: Mix.Project.config()[:app]
-
 # Use Ringlogger as the logger backend and remove :console.
 # See https://hexdocs.pm/ring_logger/readme.html for more information on
 # configuring ring_logger.

--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -83,6 +83,14 @@ config :mdns_lite,
     }
   ]<% end %>
 
+# Use shoehorn to start the main application. See the shoehorn
+# docs for separating out critical OTP applications such as those
+# involved with firmware updates.
+
+config :shoehorn,
+  init: [:nerves_runtime<%= if init_gadget? do %>, :nerves_init_gadget<% end %><%= if nerves_pack? do %>, :nerves_pack<% end %>],
+  app: Mix.Project.config()[:app]
+
 # Import target specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 # Uncomment to use target specific configurations


### PR DESCRIPTION
The shoehorn config is only used on the target and references
target-only dependencies so move it to target.exs.