### PR TITLE
Update the official system deps to 1.10/2.5

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -22,14 +22,14 @@ defmodule Mix.Tasks.Nerves.New do
   @shortdoc "Creates a new Nerves application"
 
   @targets [
-    {:rpi, "1.8"},
-    {:rpi0, "1.8"},
-    {:rpi2, "1.8"},
-    {:rpi3, "1.8"},
-    {:rpi3a, "1.8"},
-    {:rpi4, "1.8"},
-    {:bbb, "2.3"},
-    {:x86_64, "1.8"}
+    {:rpi, "1.10"},
+    {:rpi0, "1.10"},
+    {:rpi2, "1.10"},
+    {:rpi3, "1.10"},
+    {:rpi3a, "1.10"},
+    {:rpi4, "1.10"},
+    {:bbb, "2.5"},
+    {:x86_64, "1.10"}
   ]
 
   @new [

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -21,14 +21,14 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "@app :#{@app_name}"
-        assert file =~ "{:nerves_system_rpi, \"~> 1.8\", runtime: false, targets: :rpi"
-        assert file =~ "{:nerves_system_rpi0, \"~> 1.8\", runtime: false, targets: :rpi0"
-        assert file =~ "{:nerves_system_rpi2, \"~> 1.8\", runtime: false, targets: :rpi2"
-        assert file =~ "{:nerves_system_rpi3, \"~> 1.8\", runtime: false, targets: :rpi3"
-        assert file =~ "{:nerves_system_rpi3a, \"~> 1.8\", runtime: false, targets: :rpi3a"
-        assert file =~ "{:nerves_system_rpi4, \"~> 1.8\", runtime: false, targets: :rpi4"
-        assert file =~ "{:nerves_system_bbb, \"~> 2.3\", runtime: false, targets: :bbb"
-        assert file =~ "{:nerves_system_x86_64, \"~> 1.8\", runtime: false, targets: :x86_64"
+        assert file =~ "{:nerves_system_rpi, \"~> 1.10\", runtime: false, targets: :rpi"
+        assert file =~ "{:nerves_system_rpi0, \"~> 1.10\", runtime: false, targets: :rpi0"
+        assert file =~ "{:nerves_system_rpi2, \"~> 1.10\", runtime: false, targets: :rpi2"
+        assert file =~ "{:nerves_system_rpi3, \"~> 1.10\", runtime: false, targets: :rpi3"
+        assert file =~ "{:nerves_system_rpi3a, \"~> 1.10\", runtime: false, targets: :rpi3a"
+        assert file =~ "{:nerves_system_rpi4, \"~> 1.10\", runtime: false, targets: :rpi4"
+        assert file =~ "{:nerves_system_bbb, \"~> 2.5\", runtime: false, targets: :bbb"
+        assert file =~ "{:nerves_system_x86_64, \"~> 1.10\", runtime: false, targets: :x86_64"
       end)
     end)
   end
@@ -41,8 +41,8 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "@app :#{@app_name}"
-        assert file =~ "{:nerves_system_rpi, \"~> 1.8\", runtime: false, targets: :rpi"
-        refute file =~ "{:nerves_system_rpi0, \"~> 1.8\", runtime: false, targets: :rpi0"
+        assert file =~ "{:nerves_system_rpi, \"~> 1.10\", runtime: false, targets: :rpi"
+        refute file =~ "{:nerves_system_rpi0, \"~> 1.10\", runtime: false, targets: :rpi0"
       end)
     end)
   end
@@ -55,9 +55,9 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "@app :#{@app_name}"
-        assert file =~ "{:nerves_system_rpi, \"~> 1.8\", runtime: false, targets: :rpi"
-        assert file =~ "{:nerves_system_rpi3, \"~> 1.8\", runtime: false, targets: :rpi3"
-        refute file =~ "{:nerves_system_rpi0, \"~> 1.8\", runtime: false, targets: :rpi0"
+        assert file =~ "{:nerves_system_rpi, \"~> 1.10\", runtime: false, targets: :rpi"
+        assert file =~ "{:nerves_system_rpi3, \"~> 1.10\", runtime: false, targets: :rpi3"
+        refute file =~ "{:nerves_system_rpi0, \"~> 1.10\", runtime: false, targets: :rpi0"
       end)
     end)
   end


### PR DESCRIPTION
While it seems unlikely for someone making a new project to actually use
an older Nerves Systems, if they're using `nerves_pack`, they need
at least 1.10/2.5. Those systems work out of the box with `vintage_net`
due to updates to the default Busybox configuration. This changes
updates the dependencies to force the change.

`nerves_init_gadget` users don't need the new systems, but it doesn't
seem terrible to encourage users to start projects out with the current
releases.