### PR TITLE
Update Mix.Local.path_for/1 to Mix.path_for/1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -92,9 +92,11 @@ defmodule Nerves.Bootstrap.Mixfile do
   end
 
   defp archives_path do
-    if function_exported?(Mix.Local, :path_for, 1),
-      do: Mix.Local.path_for(:archive),
-      else: Mix.Local.archives_path()
+    cond do
+      function_exported?(Mix, :path_for, 1) -> apply(Mix, :path_for, [:archives])
+      function_exported?(Mix.Local, :path_for, 1) -> apply(Mix.Local, :path_for, [:archive])
+      true -> Mix.Local.archives_path()
+    end
   end
 
   defp archive_ebin(archive) do


### PR DESCRIPTION
This fixes a deprecation warning in elixir >= 1.10.0-rc.0