### PR TITLE
Support RELEASE_COOKIE environment variable and random cookie generation

### DIFF
--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -63,7 +63,7 @@ defmodule <%= app_module %>.MixProject do
   def release do
     [
       overwrite: true,
-      cookie: <%= if cookie do %>"<%= cookie %>"<% else %>"#{@app}_cookie"<% end %>,
+      cookie: <%= if cookie do %>"<%= cookie %>"<% else %>System.get_env("RELEASE_COOKIE") || "<%= Base.encode32(:crypto.strong_rand_bytes(32)) %>"<% end %>,
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],
       strip_beams: Mix.env() == :prod

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -72,12 +72,17 @@ defmodule Nerves.NewTest do
     end)
   end
 
-  test "new project provides a default cookie", context do
+  test "new project provides a default random cookie", context do
     in_tmp(context.test, fn ->
       Mix.Tasks.Nerves.New.run([@app_name])
 
       assert_file("#{@app_name}/mix.exs", fn file ->
-        assert file =~ "cookie: \"\#{@app}_cookie\""
+        [_, capture] =
+          Regex.run(~r/cookie: System\.get_env\(\"RELEASE_COOKIE\"\)\ \|\|\ \"([^"]+)/, file)
+
+        assert {:ok, data} = Base.decode32(capture)
+
+        assert 32 == byte_size(data)
       end)
     end)
   end


### PR DESCRIPTION
I realize that the default cookie generated has been intentionally set to `"#{@app}_cookie"` by default in order to easy the support burden. Unfortunately this is in opposition to the cookie recommendations in mix release, https://hexdocs.pm/mix/Mix.Tasks.Release.html and the help text for `mix nerves.new`

 > If you are setting this option manually, we recommend the cookie option to be a long and randomly  generated string, such as: Base.url_encode64(:crypto.strong_rand_bytes(40)). We also  recommend to restrict the characters in the cookie to the subset returned by Base.url_encode64/1.

> A --cookie options can be given to set the Erlang distribution cookie in
vm.args. This defaults to a randomly generated string.

