### PR TITLE
Surround iex.exs with a try..catch for safety

### DIFF
--- a/templates/new/rootfs_overlay/etc/iex.exs
+++ b/templates/new/rootfs_overlay/etc/iex.exs
@@ -1,18 +1,28 @@
 # Add Toolshed helpers to the IEx session
 use Toolshed
 
-if RingLogger in Application.get_env(:logger, :backends, []) do
-  IO.puts """
-  RingLogger is collecting log messages from Elixir and Linux. To see the
-  messages, either attach the current IEx session to the logger:
+try do
+  if RingLogger in Application.get_env(:logger, :backends, []) do
+    IO.puts("""
+    RingLogger is collecting log messages from Elixir and Linux. To see the
+    messages, either attach the current IEx session to the logger:
 
-    RingLogger.attach
+      RingLogger.attach
 
-  or print the next messages in the log:
+    or print the next messages in the log:
 
-    RingLogger.next
-  """
+      RingLogger.next
+    """)
+  end
+catch
+  what, reason ->
+    IO.puts("""
+    Something was thrown in your iex.exs. It was caught so that it wouldn't
+    exit the Erlang VM.
+
+    #{inspect(what)}: #{inspect(reason)}
+    """)
 end
 
-# Be careful when adding to this file. Nearly any error can crash the VM and
-# cause a reboot.
+# Be careful when adding outside of the try...catch. Nearly any error can crash
+# the VM and cause a reboot.


### PR DESCRIPTION
Make it easier for people to safely modify their iex.exs by giving them
a starter try..catch block to put stuff in.