### PR TITLE
Remove note about crashing Erlang

### DIFF
--- a/templates/new/rootfs_overlay/etc/iex.exs
+++ b/templates/new/rootfs_overlay/etc/iex.exs
@@ -13,6 +13,3 @@ if RingLogger in Application.get_env(:logger, :backends, []) do
     RingLogger.next
   """
 end
-
-# Be careful when adding to this file. Nearly any error can crash the VM and
-# cause a reboot.


### PR DESCRIPTION
This was fixed in Elixir 1.9.0. See
https://github.com/elixir-lang/elixir/pull/8619 for PR.