### PR TITLE
Add missing :hex dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Nerves.Bootstrap.MixProject do
 
   def application do
     [
-      extra_applications: [],
+      extra_applications: [:hex, :eex],
       mod: {Nerves.Bootstrap, []}
     ]
   end


### PR DESCRIPTION
This fixes a warning caught by Elixir 1.11:

```
warning: Hex.start/0 defined in application :hex is used by the current application but the current application does not directly depend on :hex.
```