### PR TITLE
Move docs to MIX_ENV=docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - checkout
       - <<: *install_elixir
       - <<: *install_hex_rebar
-      - run: mix deps.get --only test
+      - run: mix deps.get
       - run: mix test
       - run: mix archive.build
       - run: mix archive.install
@@ -51,7 +51,7 @@ jobs:
       - checkout
       - <<: *install_elixir
       - <<: *install_hex_rebar
-      - run: mix deps.get --only test
+      - run: mix deps.get
       - run: mix test
       - run: mix archive.build
       - run: mix archive.install

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,12 @@ defmodule Nerves.Bootstrap.MixProject do
       docs: docs(),
       description: description(),
       package: package(),
-      deps: deps()
+      deps: deps(),
+      preferred_cli_env: %{
+        docs: :docs,
+        "hex.publish": :docs,
+        "hex.build": :docs
+      }
     ]
   end
 
@@ -38,7 +43,7 @@ defmodule Nerves.Bootstrap.MixProject do
 
   defp deps do
     [
-      {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false}
+      {:ex_doc, "~> 0.22", only: :docs, runtime: false}
     ]
   end
 


### PR DESCRIPTION
This speeds up builds and also highlighted the missing :eex dependency.