### PR TITLE
Update to __STACKTRACE__ in rescue blocks.

### DIFF
--- a/lib/mix/tasks/nerves/loadpaths.ex
+++ b/lib/mix/tasks/nerves/loadpaths.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
             env_info()
           rescue
             e ->
-              reraise e, System.stacktrace()
+              reraise e, __STACKTRACE__
           end
 
         false ->

--- a/lib/mix/tasks/nerves/system.shell.ex
+++ b/lib/mix/tasks/nerves/system.shell.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Nerves.System.Shell do
             Mix.raise(@no_nerves_dep_error)
 
           _ ->
-            reraise(e, System.stacktrace())
+            reraise(e, __STACKTRACE__)
         end
     end
 


### PR DESCRIPTION
Fixes compiler warnings in Elixir 1.11