### PR TITLE
v1.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.9.0
+
+* New project generator updates
+  * Bump [NervesPack to 0.4](https://hexdocs.pm/nerves_pack/changelog.html#v0-4-0) which drops `:nerves_firwmare_ssh` in
+    favor of `:nerves_ssh` and `:ssh_subsystem_fwup` for access and updates.
+  * bump Nerves to 1.6.3
+  * bump NervesRuntime to 0.11
+  * bump RingLogger to 0.8
+
 ## 1.8.1
 
 * New project generator updates

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Nerves.New do
   @shoehorn_vsn "0.6.0"
   @runtime_vsn "0.11.3"
   @ring_logger_vsn "0.8.1"
-  @nerves_pack_vsn "0.3.3"
+  @nerves_pack_vsn "0.4.0"
   @toolshed_vsn "0.2.13"
 
   @elixir_vsn "~> 1.9"

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nerves.Bootstrap.MixProject do
   use Mix.Project
 
-  @version "1.8.1"
+  @version "1.9.0"
   @source_url "https://github.com/nerves-project/nerves_bootstrap"
 
   def project do

--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -23,9 +23,10 @@ config :nerves,
     hostname_pattern: "nerves-%s"
   ]
 
-# Authorize the device to receive firmware using your public key.
-# See https://hexdocs.pm/nerves_firmware_ssh/readme.html for more information
-# on configuring nerves_firmware_ssh.
+# Configure the device for SSH IEx prompt access and firmware updates
+#
+# * See https://hexdocs.pm/nerves_ssh/readme.html for general SSH configuration
+# * See https://hexdocs.pm/ssh_subsystem_fwup/readme.html for firmware updates
 
 keys =
   [
@@ -43,7 +44,7 @@ if keys == [],
     See your project's config.exs for this error message.
     """)
 
-config :nerves_firmware_ssh,
+config :nerves_ssh,
   authorized_keys: Enum.map(keys, &File.read!/1)
 
 # Configure the network using vintage_net

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -155,7 +155,7 @@ defmodule Nerves.NewTest do
       end)
 
       assert_file("#{@app_name}/config/target.exs", fn file ->
-        assert file =~ ~r"nerves_firmware_ssh"
+        assert file =~ ~r"nerves_ssh"
         assert file =~ ~r"vintage_net"
         assert file =~ ~r"mdns_lite"
       end)
@@ -171,7 +171,7 @@ defmodule Nerves.NewTest do
       end)
 
       assert_file("#{@app_name}/config/target.exs", fn file ->
-        assert file =~ ~r"nerves_firmware_ssh"
+        assert file =~ ~r"nerves_ssh"
         assert file =~ ~r"vintage_net"
         assert file =~ ~r"mdns_lite"
       end)
@@ -188,7 +188,7 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/config/config.exs", fn file ->
         refute file =~ ~r"nerves_pack"
-        refute file =~ ~r"nerves_firmware_ssh"
+        refute file =~ ~r"nerves_ssh"
       end)
     end)
   end


### PR DESCRIPTION
* New project generator updates
  * bump NervesPack to 0.4 which drops `:nerves_firwmare_ssh` in
    favor of `:nerves_ssh` and `:ssh_subsystem_fwup` for access and updates.
  * bump Nerves to 1.6.3
  * bump NervesRuntime to 0.11
  * bump RingLogger to 0.8
