### PR TITLE
Revert "Add missing :hex and :eex dependencies"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Nerves.Bootstrap.MixProject do
 
   def application do
     [
-      extra_applications: [:hex, :eex],
+      extra_applications: [],
       mod: {Nerves.Bootstrap, []}
     ]
   end


### PR DESCRIPTION
This reverts commit 7e5d23f30a2c8c3998c8d43930ede972634db6b3.

Adding `:hex` and `:eex` to the `extra_applications` fixed an Elixir
1.11 compiler warning, but broke the `mix` integration code. This made
compilation of any Nerves project stop working. This reverts that code
so that we can investigate and fix later.