### PR TITLE
Ignore compiler warnings for Hex and EEx

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Nerves.Bootstrap.MixProject do
       version: @version,
       elixir: "~> 1.7",
       aliases: aliases(),
-      xref: [exclude: [Nerves.Env, Nerves.Artifact]],
+      xref: [exclude: [Nerves.Env, Nerves.Artifact, Hex, Hex.API.Package, EEx]],
       docs: docs(),
       description: description(),
       package: package(),


### PR DESCRIPTION
This fixes warnings emitted in elixir 1.11.0