### PR TITLE
Move nerves_bootstrap start to config.exs

### DIFF
--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -5,6 +5,9 @@
 # is restricted to this project.
 import Config
 
+# Enable the Nerves integration with Mix
+Application.start(:nerves_bootstrap)
+
 config :<%= app_name %>, target: Mix.target()
 
 # Customize non-Elixir parts of the firmware. See

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -17,18 +17,10 @@ defmodule <%= app_module %>.MixProject do
       lockfile: "../../mix.lock",<% end %>
       start_permanent: Mix.env() == :prod,
       build_embedded: true,
-      aliases: [loadconfig: [&bootstrap/1]],
       deps: deps(),
       releases: [{@app, release()}],
       preferred_cli_target: [run: :host, test: :host]
     ]
-  end
-
-  # Starting nerves_bootstrap adds the required aliases to Mix.Project.config()
-  # Aliases are only added if MIX_TARGET is set.
-  def bootstrap(args) do
-    Application.start(:nerves_bootstrap)
-    Mix.Task.run("loadconfig", args)
   end
 
   # Run "mix help compile.app" to learn about applications.


### PR DESCRIPTION
Moving this call to the top of the config.exs performs the same action as aliasing loadconfig but allows us to further clean up the mix file. Existing projects will continue to function and this style is compatible across all supported Elixir versions.