### PR TITLE
Update new project formatting for Elixir 1.11

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -361,7 +361,7 @@ defmodule Mix.Tasks.Nerves.New do
           append_to(Path.dirname(target), Path.basename(target), render(source))
 
         :eex ->
-          contents = EEx.eval_string(render(source), binding, file: source, trim: true)
+          contents = EEx.eval_string(render(source), binding, file: source, trim: false)
           create_file(target, contents)
       end
     end

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -53,9 +53,7 @@ defmodule <%= app_module %>.MixProject do
       {:nerves_pack, "~> <%= nerves_pack_vsn %>", targets: @all_targets},<% end %>
 
       # Dependencies for specific targets
-      <%= for {target, vsn} <- targets do %>
-      {:<%= "nerves_system_#{target}" %>, "~> <%= vsn %>", runtime: false, targets: :<%= target %>},
-      <% end %>
+<%= Enum.map_join(targets, ",\n", &~s|      {:nerves_system_#{elem(&1, 0)}, "~> #{elem(&1, 1)}", runtime: false, targets: :#{elem(&1, 0)}}|) %>
     ]
   end
 


### PR DESCRIPTION
This is also compatible with previous formatter versions. It removes the trailing comma at the end of the target specific deps.