### PR TITLE
Disable busy waiting in the BEAM by default

### DIFF
--- a/templates/new/rel/vm.args.eex
+++ b/templates/new/rel/vm.args.eex
@@ -18,6 +18,12 @@
 ## See http://erlang.org/doc/system_principles/system_principles.html#code-loading-strategy
 -mode embedded
 
+## Disable scheduler busy wait to reduce idle CPU usage and avoid delaying
+## other OS processes. See http://erlang.org/doc/man/erl.html#+sbwt
++sbwt none
++sbwtdcpu none
++sbwtdio none
+
 ## Save the shell history between reboots
 ## See http://erlang.org/doc/man/kernel_app.html for additional options
 -kernel shell_history enabled


### PR DESCRIPTION
The BEAM will busy wait for a short time before letting the OS scheduler
take over as an optimization to reduce response time latency. The side
effect is to delay other OS processes from running, increase OS-reported
CPU utilization, and possibly increase the processor frequency to deal
with extra load.

Since the advantages of busy waiting are less obvious, this change turns
it off in the generated skeleton project. The intention of the comment
is to direct users to more information so that people who might be
interested in the optimization can turn it back on.