### PR TITLE
Improve new task message

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -215,15 +215,11 @@ defmodule Mix.Tasks.Nerves.New do
     install? = Mix.shell().yes?("\nFetch and install dependencies?")
 
     File.cd!(path, fn ->
-      extra =
-        if install? && Code.ensure_loaded?(Hex) do
-          cmd("mix deps.get")
-          []
-        else
-          ["  $ mix deps.get"]
-        end
+      if install? && Code.ensure_loaded?(Hex) do
+        cmd("mix deps.get")
+      end
 
-      print_mix_info(path, extra)
+      print_mix_info(path)
     end)
   end
 
@@ -255,8 +251,8 @@ defmodule Mix.Tasks.Nerves.New do
     end
   end
 
-  defp print_mix_info(path, extra) do
-    command = ["$ cd #{path}"] ++ extra
+  defp print_mix_info(path) do
+    command = ["$ cd #{path}"]
 
     Mix.shell().info("""
     Your Nerves project was created successfully.


### PR DESCRIPTION
This commit achieves the below.
If his answer is 'n' against "Fetch and install dependencies?", it shows only once "mix deps.get".

$ mix nerves.new hello_nerves
If his answer is 'n' against "Fetch and install dependencies?", it shows twice "mix deps.get".

I change Mix.Tasks.Nerves.New.print_mix_info/2 to Mix.Tasks.Nerves.New.print_mix_info/1.
If you prefer Mix.Tasks.Nerves.New.print_mix_info/2, I will re-send a pullrequest.
Would you please review?