### PR TITLE
Run iex.exs through the formatter

### DIFF
--- a/templates/new/.formatter.exs
+++ b/templates/new/.formatter.exs
@@ -1,4 +1,8 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: [
+    "{mix,.formatter}.exs",
+    "{config,lib,test}/**/*.{ex,exs}",
+    "rootfs_overlay/etc/iex.exs"
+  ]
 ]

--- a/templates/new/rootfs_overlay/etc/iex.exs
+++ b/templates/new/rootfs_overlay/etc/iex.exs
@@ -2,7 +2,7 @@
 use Toolshed
 
 if RingLogger in Application.get_env(:logger, :backends, []) do
-  IO.puts """
+  IO.puts("""
   RingLogger is collecting log messages from Elixir and Linux. To see the
   messages, either attach the current IEx session to the logger:
 
@@ -11,5 +11,5 @@ if RingLogger in Application.get_env(:logger, :backends, []) do
   or print the next messages in the log:
 
     RingLogger.next
-  """
+  """)
 end


### PR DESCRIPTION
This has a side benefit of catching syntax errors before using it on a
device.