### PR TITLE
Add placeholder file for host configuration

### DIFF
--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -26,6 +26,8 @@ config :nerves, source_date_epoch: "<%= source_date_epoch %>"
 
 config :logger, backends: [RingLogger]
 
-if Mix.target() != :host do
+if Mix.target() == :host or Mix.target() == :"" do
+  import_config "host.exs"
+else
   import_config "target.exs"
 end

--- a/templates/new/config/host.exs
+++ b/templates/new/config/host.exs
@@ -1,0 +1,3 @@
+import Config
+
+# Add configuration that is only needed when running on the host here.


### PR DESCRIPTION
Fixes #171

NOTE: I believe that Mix.target() returning `:""` when running on the host is a bug. I saw this happen with ElixirLS. I'd like to get this fixed, but adding that check seems harmless and we can always remove it when it's fixed (assuming that it is a bug).