### PR TITLE
Strip everything but docs with MIX_ENV=dev

### DIFF
--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -57,7 +57,7 @@ defmodule <%= app_module %>.MixProject do
 <% end %>      cookie: <%= if cookie do %>"<%= cookie %>"<% else %>"#{@app}_cookie"<% end %>,
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],
-      strip_beams: Mix.env() == :prod
+      strip_beams: Mix.env() == :prod or [keep: ["Docs"]]
     ]
   end
 end


### PR DESCRIPTION
Since most users don't use debug symbols, strip them out of the beams
even for dev builds. This keeps docs, though. Here's are some firmware
sizes to see the effect:

circuits_quickstart_unstripped.fw 43597619
circuits_quickstart_docs.fw 33595640
circuits_quickstart_stripped.fw 33016963

As you can see, this saves 10 MB off and retains docs.