### PR TITLE
nerves.new: bump versions and add note on systems

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -21,15 +21,15 @@ defmodule Mix.Tasks.Nerves.New do
   @shortdoc "Creates a new Nerves application"
 
   @targets [
-    {:rpi, "1.13"},
-    {:rpi0, "1.13"},
-    {:rpi2, "1.13"},
-    {:rpi3, "1.13"},
-    {:rpi3a, "1.13"},
-    {:rpi4, "1.13"},
-    {:bbb, "2.8"},
-    {:osd32mp1, "0.4"},
-    {:x86_64, "1.13"}
+    {:rpi, "1.15.0"},
+    {:rpi0, "1.15.0"},
+    {:rpi2, "1.15.0"},
+    {:rpi3, "1.15.0"},
+    {:rpi3a, "1.15.0"},
+    {:rpi4, "1.15.0"},
+    {:bbb, "2.10.0"},
+    {:osd32mp1, "0.6.0"},
+    {:x86_64, "1.15.0"}
   ]
 
   @new [

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -45,6 +45,10 @@ defmodule <%= app_module %>.MixProject do
       {:nerves_pack, "~> <%= nerves_pack_vsn %>", targets: @all_targets},<% end %>
 
       # Dependencies for specific targets
+      # NOTE: It's generally low risk and recommended to follow minor version
+      # bumps to Nerves systems. Since these include Linux kernel and Erlang
+      # version updates, please review their release notes in case
+      # changes to your application are needed.
 <%= Enum.map_join(targets, ",\n", &~s|      {:nerves_system_#{elem(&1, 0)}, "~> #{elem(&1, 1)}", runtime: false, targets: :#{elem(&1, 0)}}|) %>
     ]
   end

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -21,15 +21,18 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "@app :#{@app_name}"
-        assert file =~ "{:nerves_system_rpi, \"~> 1.13\", runtime: false, targets: :rpi"
-        assert file =~ "{:nerves_system_rpi0, \"~> 1.13\", runtime: false, targets: :rpi0"
-        assert file =~ "{:nerves_system_rpi2, \"~> 1.13\", runtime: false, targets: :rpi2"
-        assert file =~ "{:nerves_system_rpi3, \"~> 1.13\", runtime: false, targets: :rpi3"
-        assert file =~ "{:nerves_system_rpi3a, \"~> 1.13\", runtime: false, targets: :rpi3a"
-        assert file =~ "{:nerves_system_rpi4, \"~> 1.13\", runtime: false, targets: :rpi4"
-        assert file =~ "{:nerves_system_bbb, \"~> 2.8\", runtime: false, targets: :bbb"
-        assert file =~ "{:nerves_system_osd32mp1, \"~> 0.4\", runtime: false, targets: :osd32mp1"
-        assert file =~ "{:nerves_system_x86_64, \"~> 1.13\", runtime: false, targets: :x86_64"
+        assert file =~ "{:nerves_system_rpi, \"~> 1.15.0\", runtime: false, targets: :rpi"
+        assert file =~ "{:nerves_system_rpi0, \"~> 1.15.0\", runtime: false, targets: :rpi0"
+        assert file =~ "{:nerves_system_rpi2, \"~> 1.15.0\", runtime: false, targets: :rpi2"
+        assert file =~ "{:nerves_system_rpi3, \"~> 1.15.0\", runtime: false, targets: :rpi3"
+        assert file =~ "{:nerves_system_rpi3a, \"~> 1.15.0\", runtime: false, targets: :rpi3a"
+        assert file =~ "{:nerves_system_rpi4, \"~> 1.15.0\", runtime: false, targets: :rpi4"
+        assert file =~ "{:nerves_system_bbb, \"~> 2.10.0\", runtime: false, targets: :bbb"
+
+        assert file =~
+                 "{:nerves_system_osd32mp1, \"~> 0.6.0\", runtime: false, targets: :osd32mp1"
+
+        assert file =~ "{:nerves_system_x86_64, \"~> 1.15.0\", runtime: false, targets: :x86_64"
       end)
     end)
   end
@@ -42,8 +45,8 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "@app :#{@app_name}"
-        assert file =~ "{:nerves_system_rpi, \"~> 1.13\", runtime: false, targets: :rpi"
-        refute file =~ "{:nerves_system_rpi0, \"~> 1.13\", runtime: false, targets: :rpi0"
+        assert file =~ "{:nerves_system_rpi, \"~> 1.15.0\", runtime: false, targets: :rpi"
+        refute file =~ "{:nerves_system_rpi0, \"~> 1.15.0\", runtime: false, targets: :rpi0"
       end)
     end)
   end
@@ -56,9 +59,9 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "@app :#{@app_name}"
-        assert file =~ "{:nerves_system_rpi, \"~> 1.13\", runtime: false, targets: :rpi"
-        assert file =~ "{:nerves_system_rpi3, \"~> 1.13\", runtime: false, targets: :rpi3"
-        refute file =~ "{:nerves_system_rpi0, \"~> 1.13\", runtime: false, targets: :rpi0"
+        assert file =~ "{:nerves_system_rpi, \"~> 1.15.0\", runtime: false, targets: :rpi"
+        assert file =~ "{:nerves_system_rpi3, \"~> 1.15.0\", runtime: false, targets: :rpi3"
+        refute file =~ "{:nerves_system_rpi0, \"~> 1.15.0\", runtime: false, targets: :rpi0"
       end)
     end)
   end


### PR DESCRIPTION
This bumps the dependency specs in the generated mix.exs to match the
current system releases. It also specifies all three semver components
for the Nerves systems now so that it's harder to run `mix deps.update
--all` without reviewing seeing a note to review the release notes.
