### PR TITLE
Show information about the running system in IEx

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Nerves.New do
   @shoehorn_vsn "0.7.0"
   @runtime_vsn "0.11.3"
   @ring_logger_vsn "0.8.1"
-  @nerves_pack_vsn "0.4.0"
+  @nerves_pack_vsn "0.5.0"
   @toolshed_vsn "0.2.13"
 
   @elixir_vsn "~> 1.9"

--- a/templates/new/rootfs_overlay/etc/iex.exs
+++ b/templates/new/rootfs_overlay/etc/iex.exs
@@ -1,23 +1,4 @@
-IO.puts("""
-\e[34m████▄▖    \e[36m▐███
-\e[34m█▌  ▀▜█▙▄▖  \e[36m▐█
-\e[34m█▌ \e[36m▐█▄▖\e[34m▝▀█▌ \e[36m▐█   \e[39mN  E  R  V  E  S
-\e[34m█▌   \e[36m▝▀█▙▄▖ ▐█
-\e[34m███▌    \e[36m▀▜████\e[0m
-""")
+NervesMOTD.print()
 
 # Add Toolshed helpers to the IEx session
 use Toolshed
-
-if RingLogger in Application.get_env(:logger, :backends, []) do
-  IO.puts("""
-  RingLogger is collecting log messages from Elixir and Linux. To see the
-  messages, either attach the current IEx session to the logger:
-
-    RingLogger.attach
-
-  or print the next messages in the log:
-
-    RingLogger.next
-  """)
-end


### PR DESCRIPTION
This is a proposal for showing more info in the target device's IEx. As one example, it would be nice is we show the brief information about the running system.

```
❯ ssh nerves.local
Interactive Elixir (1.12.1) - press Ctrl+C to exit (type h() ENTER for help)
████▄▖    ▐███
█▌  ▀▜█▙▄▖  ▐█
█▌ ▐█▄▖▝▀█▌ ▐█   N  E  R  V  E  S
█▌   ▝▀█▙▄▖ ▐█
███▌    ▀▜████

Toolshed imported. Run h(Toolshed) for more info.
RingLogger is collecting log messages from Elixir and Linux. To see the
messages, either attach the current IEx session to the logger:

  RingLogger.attach

or print the next messages in the log:

  RingLogger.next

Nerves nerves-777f hello_nerves 0.1.0 (67035389-62c9-595c-4f05-29022f5f5775) arm
```

I cannot think of anything else that can be added to `iex.exs` right now. Potentially there is more that is generic enough to be added to `iex.exs`  🤔 

https://dev.to/mnishiguchi/customizing-iex-for-elixir-nerves-target-device-1amg


### TODO

- [x] Make sure latest `nerves_pack` supports `nerves_motd`
