### PR TITLE
Remove :name field for mdns_lite 0.8.0

### DIFF
--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -74,19 +74,16 @@ config :mdns_lite,
   # Advertise the following services over mDNS.
   services: [
     %{
-      name: "SSH Remote Login Protocol",
       protocol: "ssh",
       transport: "tcp",
       port: 22
     },
     %{
-      name: "Secure File Transfer Protocol over SSH",
       protocol: "sftp-ssh",
       transport: "tcp",
       port: 22
     },
     %{
-      name: "Erlang Port Mapper Daemon",
       protocol: "epmd",
       transport: "tcp",
       port: 4369


### PR DESCRIPTION
The name field isn't really that useful until you start dynamically
adding and removing services.
