### PR TITLE
Create projects with loose system dep specs

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -21,15 +21,15 @@ defmodule Mix.Tasks.Nerves.New do
   @shortdoc "Creates a new Nerves application"
 
   @targets [
-    {:rpi, "1.16.0"},
-    {:rpi0, "1.16.0"},
-    {:rpi2, "1.16.0"},
-    {:rpi3, "1.16.0"},
-    {:rpi3a, "1.16.0"},
-    {:rpi4, "1.16.0"},
-    {:bbb, "2.11.0"},
-    {:osd32mp1, "0.7.0"},
-    {:x86_64, "1.16.0"}
+    {:rpi, "1.17"},
+    {:rpi0, "1.17"},
+    {:rpi2, "1.17"},
+    {:rpi3, "1.17"},
+    {:rpi3a, "1.17"},
+    {:rpi4, "1.17"},
+    {:bbb, "2.12"},
+    {:osd32mp1, "0.8"},
+    {:x86_64, "1.17"}
   ]
 
   @new [

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -21,18 +21,18 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "@app :#{@app_name}"
-        assert file =~ "{:nerves_system_rpi, \"~> 1.16.0\", runtime: false, targets: :rpi"
-        assert file =~ "{:nerves_system_rpi0, \"~> 1.16.0\", runtime: false, targets: :rpi0"
-        assert file =~ "{:nerves_system_rpi2, \"~> 1.16.0\", runtime: false, targets: :rpi2"
-        assert file =~ "{:nerves_system_rpi3, \"~> 1.16.0\", runtime: false, targets: :rpi3"
-        assert file =~ "{:nerves_system_rpi3a, \"~> 1.16.0\", runtime: false, targets: :rpi3a"
-        assert file =~ "{:nerves_system_rpi4, \"~> 1.16.0\", runtime: false, targets: :rpi4"
-        assert file =~ "{:nerves_system_bbb, \"~> 2.11.0\", runtime: false, targets: :bbb"
+        assert file =~ "{:nerves_system_rpi, \"~> 1.17\", runtime: false, targets: :rpi"
+        assert file =~ "{:nerves_system_rpi0, \"~> 1.17\", runtime: false, targets: :rpi0"
+        assert file =~ "{:nerves_system_rpi2, \"~> 1.17\", runtime: false, targets: :rpi2"
+        assert file =~ "{:nerves_system_rpi3, \"~> 1.17\", runtime: false, targets: :rpi3"
+        assert file =~ "{:nerves_system_rpi3a, \"~> 1.17\", runtime: false, targets: :rpi3a"
+        assert file =~ "{:nerves_system_rpi4, \"~> 1.17\", runtime: false, targets: :rpi4"
+        assert file =~ "{:nerves_system_bbb, \"~> 2.12\", runtime: false, targets: :bbb"
 
         assert file =~
-                 "{:nerves_system_osd32mp1, \"~> 0.7.0\", runtime: false, targets: :osd32mp1"
+                 "{:nerves_system_osd32mp1, \"~> 0.8\", runtime: false, targets: :osd32mp1"
 
-        assert file =~ "{:nerves_system_x86_64, \"~> 1.16.0\", runtime: false, targets: :x86_64"
+        assert file =~ "{:nerves_system_x86_64, \"~> 1.17\", runtime: false, targets: :x86_64"
       end)
     end)
   end
@@ -45,8 +45,8 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "@app :#{@app_name}"
-        assert file =~ "{:nerves_system_rpi, \"~> 1.16.0\", runtime: false, targets: :rpi"
-        refute file =~ "{:nerves_system_rpi0, \"~> 1.16.0\", runtime: false, targets: :rpi0"
+        assert file =~ "{:nerves_system_rpi, \"~> 1.17\", runtime: false, targets: :rpi"
+        refute file =~ "{:nerves_system_rpi0, \"~> 1.17\", runtime: false, targets: :rpi0"
       end)
     end)
   end
@@ -59,9 +59,9 @@ defmodule Nerves.NewTest do
 
       assert_file("#{@app_name}/mix.exs", fn file ->
         assert file =~ "@app :#{@app_name}"
-        assert file =~ "{:nerves_system_rpi, \"~> 1.16.0\", runtime: false, targets: :rpi"
-        assert file =~ "{:nerves_system_rpi3, \"~> 1.16.0\", runtime: false, targets: :rpi3"
-        refute file =~ "{:nerves_system_rpi0, \"~> 1.16.0\", runtime: false, targets: :rpi0"
+        assert file =~ "{:nerves_system_rpi, \"~> 1.17\", runtime: false, targets: :rpi"
+        assert file =~ "{:nerves_system_rpi3, \"~> 1.17\", runtime: false, targets: :rpi3"
+        refute file =~ "{:nerves_system_rpi0, \"~> 1.17\", runtime: false, targets: :rpi0"
       end)
     end)
   end


### PR DESCRIPTION
The previous idea was to create projects with tighter specs to encourage
people to be more intentional with their Nerves system. However, it
looks like this just makes us update the bootstrap project more
frequently. Since I forgot to do this last Nerves systems release, I've
noticed projects appearing using older systems and that's not great
either.
