### PR TITLE
Remove old reference to Mix.Config

### DIFF
--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -1,8 +1,8 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
+# This file is responsible for configuring your application and its
+# dependencies.
 #
-# This configuration file is loaded before any dependency and
-# is restricted to this project.
+# This configuration file is loaded before any dependency and is restricted to
+# this project.
 import Config
 
 # Enable the Nerves integration with Mix


### PR DESCRIPTION
Mix.Config has been replaced for a while. This also re-wraps the comment
text.
