### PR TITLE
Switch instructions from `firmware.burn` to `burn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ export `MIX_TARGET`. Here's a common build script:
 export MIX_TARGET=rpi3
 mix deps.get
 mix firmware
-mix firmware.burn
+mix burn
 ```
 
 If you look at the generated `mix.exs`, you'll see how `MIX_TARGET` is used.

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -278,7 +278,7 @@ defmodule Mix.Tasks.Nerves.New do
 
     If your target boots up using an SDCard (like the Raspberry Pi 3),
     then insert an SDCard into a reader on your computer and run:
-      $ mix firmware.burn
+      $ mix burn
 
     Plug the SDCard into the target and power it up. See target documentation
     above for more information and other targets.

--- a/templates/new/README.md
+++ b/templates/new/README.md
@@ -21,7 +21,7 @@ To start your Nerves app:
     `MIX_TARGET=my_target`. For example, `MIX_TARGET=rpi3`
   * Install dependencies with `mix deps.get`
   * Create firmware with `mix firmware`
-  * Burn to an SD card with `mix firmware.burn`
+  * Burn to an SD card with `mix burn`
 
 ## Learn more
 


### PR DESCRIPTION
I'm not 100% sure this is correct, but the `mix firmware` prompt now tells you to run `mix burn` instead of `mix firmware.burn` so it seems to me that nerves_bootstrap should be updated as well. If that's not the case then feel free to close.