### PR TITLE
Generate mdns `:hosts` configuration

### DIFF
--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -62,13 +62,15 @@ config :vintage_net,
   ]
 
 config :mdns_lite,
-  # The `host` key specifies what hostnames mdns_lite advertises.  `:hostname`
+  # The `hosts` key specifies what hostnames mdns_lite advertises.  `:hostname`
   # advertises the device's hostname.local. For the official Nerves systems, this
-  # is "nerves-<4 digit serial#>.local".  mdns_lite also advertises
-  # "nerves.local" for convenience. If more than one Nerves device is on the
-  # network, delete "nerves" from the list.
+  # is "nerves-<4 digit serial#>.local".  The `"nerves"` host causes mdns_lite
+  # to advertise "nerves.local" for convenience. If more than one Nerves device
+  # is on the network, it is recommended to delete "nerves" from the list
+  # because otherwise any of the devices may respond to nerves.local leading to
+  # unpredictable behavior.
 
-  host: [:hostname, "nerves"],
+  hosts: [:hostname, "nerves"],
   ttl: 120,
 
   # Advertise the following services over mDNS.


### PR DESCRIPTION
Previously `:host` was generated, however `:host` is deprecated. Also explain more directly that `"nerves"` is what generates the `nerves.local` domain (and not something internal to mdns_lite) along with the reason why you'd want to remove `"nerves"` if you have multiple nerves devices on the same network.