### PR TITLE
Bump nerves_pack version in template

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Nerves.New do
   @shoehorn_vsn "0.9.0"
   @runtime_vsn "0.11.6"
   @ring_logger_vsn "0.8.3"
-  @nerves_pack_vsn "0.6.0"
+  @nerves_pack_vsn "0.7.0"
   @toolshed_vsn "0.2.13"
 
   @elixir_vsn "~> 1.9"


### PR DESCRIPTION
As of writing, the latest version of `nerves_pack` is [v0.7.0](https://github.com/nerves-project/nerves_pack/releases/tag/v0.7.0). My guess is `nerves_pack` is intentionally locked down to `v0.6.0` due to potential breaking change. But it means many Nerves users will not use latest  `nerves_pack` unless they manually unlock and update `nerves_pack`. Is it OK?

If the minimal supported Elixir version `"~> 1.9"` is the issue, isn't it time to update it?

### Changes

- Bump nerves_pack_vsn from `0.6.0` to `0.7.0`
- ~Bump elixir_vsn from `~> 1.9` to `~> 1.10`~


