### PR TITLE
Require Elixir 1.11 or later

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2
 
 defaults: &defaults
   working_directory: ~/repo
+  environment:
+    LC_ALL: C.UTF-8
 
 install_hex_rebar: &install_hex_rebar
   run:
@@ -13,7 +15,7 @@ install_hex_rebar: &install_hex_rebar
 jobs:
   build_elixir_1_13_otp_24:
     docker:
-      - image: hexpm/elixir:1.13.3-erlang-24.3.3-alpine-3.15.3
+      - image: hexpm/elixir:1.13.4-erlang-24.3.3-alpine-3.15.3
     <<: *defaults
     steps:
       - checkout
@@ -40,31 +42,7 @@ jobs:
 
   build_elixir_1_11_otp_23:
     docker:
-      - image: hexpm/elixir:1.11.2-erlang-23.1.2-alpine-3.12.1
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - run: mix deps.get
-      - run: mix test
-      - run: mix archive.build
-      - run: mix archive.install
-
-  build_elixir_1_10_otp_23:
-    docker:
-      - image: hexpm/elixir:1.10.4-erlang-23.1.2-alpine-3.12.1
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - run: mix deps.get
-      - run: mix test
-      - run: mix archive.build
-      - run: mix archive.install
-
-  build_elixir_1_9_otp_22:
-    docker:
-      - image: hexpm/elixir:1.9.4-erlang-22.3.4.9-alpine-3.12.0
+      - image: hexpm/elixir:1.11.4-erlang-23.3.4-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
@@ -81,5 +59,3 @@ workflows:
       - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23
-      - build_elixir_1_10_otp_23
-      - build_elixir_1_9_otp_22

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.Nerves.New do
   @nerves_pack_vsn "0.6.0"
   @toolshed_vsn "0.2.13"
 
-  @elixir_vsn "~> 1.9"
+  @elixir_vsn "~> 1.11"
   @shortdoc "Creates a new Nerves application"
 
   @targets [

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Nerves.Bootstrap.MixProject do
     [
       app: :nerves_bootstrap,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.11",
       aliases: aliases(),
       xref: [exclude: [Nerves.Env, Nerves.Artifact, Hex, Hex.API.Package, EEx]],
       docs: docs(),


### PR DESCRIPTION
Elixir 1.9 and Elixir 1.10 still work if you're careful pulling in
dependencies, but won't be supported.
