### PR TITLE
Remove :"" workaround

### DIFF
--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -26,7 +26,7 @@ config :nerves, source_date_epoch: "<%= source_date_epoch %>"
 
 config :logger, backends: [RingLogger]
 
-if Mix.target() == :host or Mix.target() == :"" do
+if Mix.target() == :host do
   import_config "host.exs"
 else
   import_config "target.exs"


### PR DESCRIPTION
This was required from Elixir versions before Elixir 1.11.3. Now that
Elixir 1.11 is required, remove it.

Fixes #217
