### PR TITLE
Fix trivial credo/spec warnings

### DIFF
--- a/lib/mix/nerves/io.ex
+++ b/lib/mix/nerves/io.ex
@@ -1,8 +1,8 @@
 defmodule Mix.Nerves.IO do
+  @moduledoc false
   @app Mix.Project.config()[:app]
 
-  @moduledoc false
-
+  @spec debug_info(String.t(), String.t(), atom()) :: :ok
   def debug_info(header, text \\ "", loc \\ @app) do
     if System.get_env("NERVES_DEBUG") == "1" do
       shell_info(header, text, loc)
@@ -11,16 +11,19 @@ defmodule Mix.Nerves.IO do
     :ok
   end
 
+  @spec shell_info(String.t(), String.t(), atom()) :: :ok
   def shell_info(header, text \\ "", loc \\ @app) do
     Mix.shell().info([:inverse, "|#{loc}| #{header}", :reset])
     Mix.shell().info(text)
   end
 
+  @spec shell_warn(String.t(), String.t(), atom()) :: :ok
   def shell_warn(header, text \\ "", loc \\ @app) do
     Mix.shell().error([:inverse, :red, "|#{loc}| #{header}", :reset])
     Mix.shell().error(text)
   end
 
+  @spec nerves_env_info() :: :ok
   def nerves_env_info() do
     Mix.shell().info([
       :green,

--- a/lib/mix/tasks/nerves/clean.ex
+++ b/lib/mix/tasks/nerves/clean.ex
@@ -1,7 +1,4 @@
 defmodule Mix.Tasks.Nerves.Clean do
-  use Mix.Task
-  import Mix.Nerves.IO
-
   @shortdoc "Cleans dependencies and build artifacts"
 
   @moduledoc """
@@ -13,6 +10,9 @@ defmodule Mix.Tasks.Nerves.Clean do
     * `dep1 dep2` - the names of Nerves dependencies to be cleaned, separated by spaces
     * `--all` - cleans all Nerves dependencies
   """
+
+  use Mix.Task
+  import Mix.Nerves.IO
 
   @switches [all: :boolean]
 

--- a/lib/mix/tasks/nerves/deps.get.ex
+++ b/lib/mix/tasks/nerves/deps.get.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Nerves.Deps.Get do
+  @moduledoc false
   use Mix.Task
 
   import Mix.Nerves.IO
 
-  @moduledoc false
-
+  @impl Mix.Task
   def run(_argv) do
     debug_info("Nerves.Deps.Get Start")
     nerves_env_info()

--- a/lib/mix/tasks/nerves/env.ex
+++ b/lib/mix/tasks/nerves/env.ex
@@ -1,11 +1,11 @@
 defmodule Mix.Tasks.Nerves.Env do
+  @moduledoc false
   use Mix.Task
   import Mix.Nerves.IO
 
-  @moduledoc false
-
   @switches [info: :boolean, disable: :boolean]
 
+  @impl Mix.Task
   def run(argv) do
     debug_info("Env Start")
     {opts, _, _} = OptionParser.parse(argv, switches: @switches)
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Nerves.Env do
       # This is the same code as Nerves.Env.disable/0, but I can't call that
       # because we're about to load it immediately below. I also can't call it
       # after it's loaded below because the act of compiling the nerves dep
-      # calls deps.precomile, which causes the system to get compiled unless
+      # calls deps.precompile, which causes the system to get compiled unless
       # Nerves.Env is disabled, which is what I'm trying to do here. :&
       # This could probably be solved by moving Nerves.Env into nerves_bootstrap
       System.put_env("NERVES_ENV_DISABLED", "1")
@@ -37,6 +37,7 @@ defmodule Mix.Tasks.Nerves.Env do
     if opts[:info], do: print_env()
   end
 
+  @spec print_env() :: :ok
   def print_env() do
     System.put_env("NERVES_DEBUG", "1")
     debug_info("Environment Package List")

--- a/lib/mix/tasks/nerves/loadpaths.ex
+++ b/lib/mix/tasks/nerves/loadpaths.ex
@@ -1,9 +1,9 @@
 defmodule Mix.Tasks.Nerves.Loadpaths do
+  @moduledoc false
   use Mix.Task
   import Mix.Nerves.IO
 
-  @moduledoc false
-
+  @impl Mix.Task
   def run(_args) do
     unless System.get_env("NERVES_PRECOMPILE") == "1" do
       debug_info("Loadpaths Start")
@@ -29,14 +29,15 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
     end
   end
 
-  def env(k) do
+  defp env(k) do
     case System.get_env(k) do
       unset when unset == nil or unset == "" -> "unset"
       set -> Path.relative_to_cwd(set)
     end
   end
 
-  def env_info do
+  @spec env_info() :: :ok
+  def env_info() do
     debug_info("Environment Variable List", """
       target:     #{Nerves.Bootstrap.mix_target()}
       toolchain:  #{env("NERVES_TOOLCHAIN")}

--- a/lib/mix/tasks/nerves/local.ex
+++ b/lib/mix/tasks/nerves/local.ex
@@ -1,6 +1,4 @@
 defmodule Mix.Tasks.Local.Nerves do
-  use Mix.Task
-
   @shortdoc "Checks for updates to nerves_bootstrap"
 
   @moduledoc """
@@ -12,6 +10,8 @@ defmodule Mix.Tasks.Local.Nerves do
 
   This accepts the same command line options as `archive.install`.
   """
+  use Mix.Task
+
   @impl Mix.Task
   def run(_args) do
     Mix.Task.run("archive.install", ["hex", "nerves_bootstrap", "~> 1.0"])

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -1,66 +1,5 @@
 defmodule Mix.Tasks.Nerves.New do
-  use Mix.Task
-  import Mix.Generator
-
-  @nerves Path.expand("../../../..", __DIR__)
-
-  @bootstrap_vsn Mix.Project.config()[:version]
-  @bootstrap_vsn_no_patch (
-                            v = Version.parse!(@bootstrap_vsn)
-                            "#{v.major}.#{v.minor}"
-                          )
-  @nerves_vsn "1.7.15"
-  @nerves_dep ~s[{:nerves, "~> #{@nerves_vsn}", runtime: false}]
-  @shoehorn_vsn "0.9.0"
-  @runtime_vsn "0.11.6"
-  @ring_logger_vsn "0.8.3"
-  @nerves_pack_vsn "0.7.0"
-  @toolshed_vsn "0.2.13"
-
-  @elixir_vsn "~> 1.11"
   @shortdoc "Creates a new Nerves application"
-
-  @targets [
-    {:rpi, "1.18"},
-    {:rpi0, "1.18"},
-    {:rpi2, "1.18"},
-    {:rpi3, "1.18"},
-    {:rpi3a, "1.18"},
-    {:rpi4, "1.18"},
-    {:bbb, "2.13"},
-    {:osd32mp1, "0.9"},
-    {:x86_64, "1.18"}
-  ]
-
-  @new [
-    {:eex, "new/config/config.exs", "config/config.exs"},
-    {:eex, "new/config/host.exs", "config/host.exs"},
-    {:eex, "new/config/target.exs", "config/target.exs"},
-    {:eex, "new/lib/app_name.ex", "lib/app_name.ex"},
-    {:eex, "new/lib/app_name/application.ex", "lib/app_name/application.ex"},
-    {:eex, "new/test/test_helper.exs", "test/test_helper.exs"},
-    {:eex, "new/test/app_name_test.exs", "test/app_name_test.exs"},
-    {:text, "new/rel/vm.args.eex", "rel/vm.args.eex"},
-    {:eex, "new/rootfs_overlay/etc/iex.exs", "rootfs_overlay/etc/iex.exs"},
-    {:text, "new/.gitignore", ".gitignore"},
-    {:text, "new/.formatter.exs", ".formatter.exs"},
-    {:eex, "new/mix.exs", "mix.exs"},
-    {:eex, "new/README.md", "README.md"},
-    {:keep, "new/rel", "rel"}
-  ]
-
-  @reserved_names ~w[nerves]
-
-  # Embed all defined templates
-  root = Path.expand("../../../../templates", __DIR__)
-
-  for {format, source, _} <- @new do
-    unless format == :keep do
-      @external_resource Path.join(root, source)
-      defp render(unquote(source)), do: unquote(File.read!(Path.join(root, source)))
-    end
-  end
-
   @moduledoc """
   Creates a new Nerves project
 
@@ -105,6 +44,67 @@ defmodule Mix.Tasks.Nerves.New do
 
       mix nerves.new blinky --no-nerves-pack
   """
+
+  use Mix.Task
+  import Mix.Generator
+
+  @nerves Path.expand("../../../..", __DIR__)
+
+  @bootstrap_vsn Mix.Project.config()[:version]
+  @bootstrap_vsn_no_patch (
+                            v = Version.parse!(@bootstrap_vsn)
+                            "#{v.major}.#{v.minor}"
+                          )
+  @nerves_vsn "1.7.15"
+  @nerves_dep ~s[{:nerves, "~> #{@nerves_vsn}", runtime: false}]
+  @shoehorn_vsn "0.9.0"
+  @runtime_vsn "0.11.6"
+  @ring_logger_vsn "0.8.3"
+  @nerves_pack_vsn "0.7.0"
+  @toolshed_vsn "0.2.13"
+
+  @elixir_vsn "~> 1.11"
+
+  @targets [
+    {:rpi, "1.18"},
+    {:rpi0, "1.18"},
+    {:rpi2, "1.18"},
+    {:rpi3, "1.18"},
+    {:rpi3a, "1.18"},
+    {:rpi4, "1.18"},
+    {:bbb, "2.13"},
+    {:osd32mp1, "0.9"},
+    {:x86_64, "1.18"}
+  ]
+
+  @new [
+    {:eex, "new/config/config.exs", "config/config.exs"},
+    {:eex, "new/config/host.exs", "config/host.exs"},
+    {:eex, "new/config/target.exs", "config/target.exs"},
+    {:eex, "new/lib/app_name.ex", "lib/app_name.ex"},
+    {:eex, "new/lib/app_name/application.ex", "lib/app_name/application.ex"},
+    {:eex, "new/test/test_helper.exs", "test/test_helper.exs"},
+    {:eex, "new/test/app_name_test.exs", "test/app_name_test.exs"},
+    {:text, "new/rel/vm.args.eex", "rel/vm.args.eex"},
+    {:eex, "new/rootfs_overlay/etc/iex.exs", "rootfs_overlay/etc/iex.exs"},
+    {:text, "new/.gitignore", ".gitignore"},
+    {:text, "new/.formatter.exs", ".formatter.exs"},
+    {:eex, "new/mix.exs", "mix.exs"},
+    {:eex, "new/README.md", "README.md"},
+    {:keep, "new/rel", "rel"}
+  ]
+
+  @reserved_names ~w[nerves]
+
+  # Embed all defined templates
+  root = Path.expand("../../../../templates", __DIR__)
+
+  for {format, source, _} <- @new do
+    unless format == :keep do
+      @external_resource Path.join(root, source)
+      defp render(unquote(source)), do: unquote(File.read!(Path.join(root, source)))
+    end
+  end
 
   @switches [
     app: :string,
@@ -371,17 +371,15 @@ defmodule Mix.Tasks.Nerves.New do
   end
 
   defp in_umbrella?(app_path) do
-    try do
-      umbrella = Path.expand(Path.join([app_path, "..", ".."]))
+    umbrella = Path.expand(Path.join([app_path, "..", ".."]))
 
-      File.exists?(Path.join(umbrella, "mix.exs")) &&
-        Mix.Project.in_project(:umbrella_check, umbrella, fn _ ->
-          path = Mix.Project.config()[:apps_path]
-          path && Path.expand(path) == Path.join(umbrella, "apps")
-        end)
-    catch
-      _, _ -> false
-    end
+    File.exists?(Path.join(umbrella, "mix.exs")) &&
+      Mix.Project.in_project(:umbrella_check, umbrella, fn _ ->
+        path = Mix.Project.config()[:apps_path]
+        path && Path.expand(path) == Path.join(umbrella, "apps")
+      end)
+  catch
+    _, _ -> false
   end
 
   defp generate_source_date_epoch() do

--- a/lib/mix/tasks/nerves/precompile.ex
+++ b/lib/mix/tasks/nerves/precompile.ex
@@ -1,11 +1,11 @@
 defmodule Mix.Tasks.Nerves.Precompile do
+  @moduledoc false
   use Mix.Task
   import Mix.Nerves.IO
 
-  @moduledoc false
-
   @switches [loadpaths: :boolean]
 
+  @impl Mix.Task
   def run(args) do
     debug_info("Precompile Start")
 
@@ -41,12 +41,10 @@ defmodule Mix.Tasks.Nerves.Precompile do
   end
 
   defp compile(%{app: app}) do
-    cond do
-      Mix.Project.config()[:app] == app ->
-        Mix.Tasks.Compile.run([app, "--include-children"])
-
-      true ->
-        Mix.Tasks.Deps.Compile.run([app, "--no-deps-check", "--include-children"])
+    if Mix.Project.config()[:app] == app do
+      Mix.Tasks.Compile.run([app, "--include-children"])
+    else
+      Mix.Tasks.Deps.Compile.run([app, "--no-deps-check", "--include-children"])
     end
   end
 

--- a/lib/mix/tasks/nerves/system.shell.ex
+++ b/lib/mix/tasks/nerves/system.shell.ex
@@ -1,6 +1,4 @@
 defmodule Mix.Tasks.Nerves.System.Shell do
-  use Mix.Task
-
   @shortdoc "Enter a shell to configure a custom system"
 
   @moduledoc """
@@ -16,6 +14,7 @@ defmodule Mix.Tasks.Nerves.System.Shell do
       mix nerves.system.shell
 
   """
+  use Mix.Task
 
   @standard_error_message """
   Make sure you run this task from a Nerves-based project or the source directory of a custom Nerves system.
@@ -38,6 +37,7 @@ defmodule Mix.Tasks.Nerves.System.Shell do
   """
 
   @doc false
+  @spec run([String.t()]) :: :ok
   def run(_argv) do
     # We unregister :user so that the process currently holding fd 0 (stdin)
     # can't send an error message to the console when we steal it.
@@ -74,5 +74,7 @@ defmodule Mix.Tasks.Nerves.System.Shell do
 
     # Set :user back to the real one
     Process.register(user, :user)
+
+    :ok
   end
 end

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -1,12 +1,10 @@
 defmodule Nerves.Bootstrap do
+  @moduledoc false
   use Application
 
   @version Mix.Project.config()[:version]
 
-  # See https://hexdocs.pm/elixir/Application.html
-  # for more information on OTP Applications
-  @moduledoc false
-
+  @impl Application
   def start(_type, _args) do
     Nerves.Bootstrap.Aliases.init()
     {:ok, self()}
@@ -15,7 +13,8 @@ defmodule Nerves.Bootstrap do
   @doc """
   Returns the version of nerves_bootstrap
   """
-  def version, do: @version
+  @spec version() :: String.t()
+  def version(), do: @version
 
   @doc """
   Add the required Nerves bootstrap aliases to the existing ones
@@ -25,33 +24,33 @@ defmodule Nerves.Bootstrap do
   @doc """
   Check the nerves_bootstrap updates from hex
   """
+  @spec check_for_update() :: :ok
   def check_for_update() do
-    try do
-      Hex.start()
-      {:ok, {200, resp, _}} = Hex.API.Package.get("hexpm", "nerves_bootstrap")
+    Hex.start()
+    {:ok, {200, resp, _}} = Hex.API.Package.get("hexpm", "nerves_bootstrap")
 
-      current_version =
-        Nerves.Bootstrap.version()
-        |> Version.parse!()
+    current_version =
+      Nerves.Bootstrap.version()
+      |> Version.parse!()
 
-      release_versions =
-        resp
-        |> Map.get("releases")
-        |> Enum.map(&Map.get(&1, "version"))
-        |> Enum.map(&Version.parse!/1)
+    release_versions =
+      resp
+      |> Map.get("releases")
+      |> Enum.map(&Map.get(&1, "version"))
+      |> Enum.map(&Version.parse!/1)
 
-      case check_for_update(release_versions, current_version) do
-        nil ->
-          :noop
+    case check_for_update(release_versions, current_version) do
+      nil ->
+        :ok
 
-        latest_version ->
-          render_update_message(current_version, latest_version)
-      end
-    rescue
-      _e -> :noop
+      latest_version ->
+        render_update_message(current_version, latest_version)
     end
+  rescue
+    _e -> :ok
   end
 
+  @spec check_for_update([Version.t()], Version.t()) :: Version.t() | nil
   def check_for_update(releases, current_version) do
     releases
     |> filter_pre_release(current_version)
@@ -60,6 +59,7 @@ defmodule Nerves.Bootstrap do
     |> List.first()
   end
 
+  @spec render_update_message(any, %{:pre => any, optional(any) => any}) :: :ok
   def render_update_message(current_version, %{pre: pre} = latest_version) do
     message =
       "A new version of Nerves bootstrap is available(#{current_version} < #{latest_version}), " <>
@@ -84,7 +84,8 @@ defmodule Nerves.Bootstrap do
     ])
   end
 
-  def mix_target do
+  @spec mix_target() :: atom()
+  def mix_target() do
     if function_exported?(Mix, :target, 0) do
       apply(Mix, :target, [])
     else

--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -1,6 +1,7 @@
 defmodule Nerves.Bootstrap.Aliases do
   @moduledoc false
 
+  @spec init() :: :ok
   def init() do
     with %{} <- Mix.ProjectStack.peek(),
          %{name: name, config: config, file: file} <- Mix.ProjectStack.pop(),
@@ -14,7 +15,7 @@ defmodule Nerves.Bootstrap.Aliases do
     else
       # We are not at the top of the stack. Do nothing.
       _ ->
-        :noop
+        :ok
     end
   end
 
@@ -28,18 +29,21 @@ defmodule Nerves.Bootstrap.Aliases do
     update_in(config, [:aliases], &add_target_aliases(&1))
   end
 
+  @spec add_aliases(keyword()) :: keyword()
   def add_aliases(aliases) do
     aliases
     |> add_host_aliases()
     |> add_target_aliases()
   end
 
+  @spec add_host_aliases(keyword()) :: keyword()
   def add_host_aliases(aliases) do
     aliases
     |> append("deps.get", "nerves.deps.get")
     |> replace("deps.update", &Nerves.Bootstrap.Aliases.deps_update/1)
   end
 
+  @spec add_target_aliases(keyword()) :: keyword()
   def add_target_aliases(aliases) do
     aliases
     |> prepend("deps.loadpaths", "nerves.loadpaths")
@@ -47,6 +51,7 @@ defmodule Nerves.Bootstrap.Aliases do
     |> replace("run", &Nerves.Bootstrap.Aliases.run/1)
   end
 
+  @spec run([String.t()]) :: :ok
   def run(args) do
     case Nerves.Bootstrap.mix_target() do
       :host ->
@@ -60,6 +65,7 @@ defmodule Nerves.Bootstrap.Aliases do
     end
   end
 
+  @spec deps_update([String.t()]) :: :ok
   def deps_update(args) do
     Mix.Tasks.Deps.Update.run(args)
     Mix.Tasks.Nerves.Deps.Get.run([])

--- a/test/mix_helper.exs
+++ b/test/mix_helper.exs
@@ -1,12 +1,17 @@
 Mix.shell(Mix.Shell.Process)
 
 defmodule MixHelper do
+  @moduledoc false
+
   import ExUnit.Assertions
+
   # Much <3 to Phoenix for this code
-  def tmp_path do
+  @spec tmp_path() :: binary()
+  def tmp_path() do
     Path.expand("../../tmp", __DIR__)
   end
 
+  @spec in_tmp(atom(), (() -> any())) :: any()
   def in_tmp(which, function) do
     path = Path.join(tmp_path(), to_string(which))
     File.rm_rf!(path)
@@ -14,28 +19,19 @@ defmodule MixHelper do
     File.cd!(path, function)
   end
 
+  @spec assert_file(File.t()) :: :ok | no_return()
   def assert_file(file) do
     assert File.regular?(file), "Expected #{file} to exist, but does not"
   end
 
+  @spec refute_file(File.t()) :: :ok | no_return()
   def refute_file(file) do
     refute File.regular?(file), "Expected #{file} to not exist, but it does"
   end
 
-  def assert_file(file, match) do
-    cond do
-      is_list(match) ->
-        assert_file(file, &Enum.each(match, fn m -> assert &1 =~ m end))
-
-      is_binary(match) or Regex.regex?(match) ->
-        assert_file(file, &assert(&1 =~ match))
-
-      is_function(match, 1) ->
-        assert_file(file)
-        match.(File.read!(file))
-
-      true ->
-        raise inspect({file, match})
-    end
+  @spec assert_file(File.t(), (binary() -> :ok)) :: :ok | no_return()
+  def assert_file(file, match) when is_function(match, 1) do
+    assert_file(file)
+    match.(File.read!(file))
   end
 end


### PR DESCRIPTION
This is a small step in getting nerves_bootstrap to pass our standard
credo and dialyzer checks. There's still quite a bit more.
