### PR TITLE
Move core tooling to `:nerves` (backwards compatible)

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,15 +1,15 @@
 # Run `mix dialyzer --format short` for strings
 [
-  {"lib/mix/tasks/nerves/clean.ex:32:unknown_function Function Nerves.Env.packages/0 does not exist."},
-  {"lib/mix/tasks/nerves/clean.ex:48:unknown_function Function Nerves.Env.package/1 does not exist."},
-  {"lib/mix/tasks/nerves/clean.ex:52:unknown_function Function Nerves.Env.clean/1 does not exist."},
-  {"lib/mix/tasks/nerves/env.ex:31:unknown_function Function Nerves.Env.start/0 does not exist."},
-  {"lib/mix/tasks/nerves/env.ex:40:unknown_function Function Nerves.Env.packages/0 does not exist."},
-  {"lib/mix/tasks/nerves/loadpaths.ex:16:unknown_function Function Nerves.Env.bootstrap/0 does not exist."},
-  {"lib/mix/tasks/nerves/precompile.ex:25:unknown_function Function Nerves.Env.packages/0 does not exist."},
-  {"lib/mix/tasks/nerves/precompile.ex:57:unknown_function Function Nerves.Artifact.expand_sites/1 does not exist."},
-  {"lib/mix/tasks/nerves/precompile.ex:58:unknown_function Function Nerves.Artifact.stale?/1 does not exist."},
-  {"lib/mix/tasks/nerves/system.shell.ex:62:unknown_function Function Nerves.Env.system/0 does not exist."},
-  {"lib/nerves_bootstrap.ex:29:unknown_function Function Hex.start/0 does not exist."},
-  {"lib/nerves_bootstrap.ex:30:unknown_function Function Hex.API.Package.get/2 does not exist."}
+  {"lib/mix/tasks/nerves/bootstrap.clean.ex:33:unknown_function Function Nerves.Env.packages/0 does not exist."},
+  {"lib/mix/tasks/nerves/bootstrap.clean.ex:49:unknown_function Function Nerves.Env.package/1 does not exist."},
+  {"lib/mix/tasks/nerves/bootstrap.clean.ex:53:unknown_function Function Nerves.Env.clean/1 does not exist."},
+  {"lib/mix/tasks/nerves/bootstrap.env.ex:31:unknown_function Function Nerves.Env.start/0 does not exist."},
+  {"lib/mix/tasks/nerves/bootstrap.env.ex:40:unknown_function Function Nerves.Env.packages/0 does not exist."},
+  {"lib/mix/tasks/nerves/bootstrap.loadpaths.ex:16:unknown_function Function Nerves.Env.bootstrap/0 does not exist."},
+  {"lib/mix/tasks/nerves/bootstrap.precompile.ex:25:unknown_function Function Nerves.Env.packages/0 does not exist."},
+  {"lib/mix/tasks/nerves/bootstrap.precompile.ex:57:unknown_function Function Nerves.Artifact.expand_sites/1 does not exist."},
+  {"lib/mix/tasks/nerves/bootstrap.precompile.ex:58:unknown_function Function Nerves.Artifact.stale?/1 does not exist."},
+  {"lib/mix/tasks/nerves/bootstrap.system.shell.ex:63:unknown_function Function Nerves.Env.system/0 does not exist."},
+  {"lib/nerves_bootstrap.ex:39:unknown_function Function Hex.start/0 does not exist."},
+  {"lib/nerves_bootstrap.ex:40:unknown_function Function Hex.API.Package.get/2 does not exist."}
 ]

--- a/lib/mix/nerves/bootstrap.io.ex
+++ b/lib/mix/nerves/bootstrap.io.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Nerves.IO do
+defmodule Mix.Nerves.Bootstrap.IO do
   @moduledoc false
   @app Mix.Project.config()[:app]
 

--- a/lib/mix/tasks/nerves/bootstrap.clean.ex
+++ b/lib/mix/tasks/nerves/bootstrap.clean.ex
@@ -1,5 +1,6 @@
-defmodule Mix.Tasks.Nerves.Clean do
+defmodule Mix.Tasks.Nerves.Bootstrap.Clean do
   @shortdoc "Cleans dependencies and build artifacts"
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
 
   @moduledoc """
   Cleans dependencies and build artifacts
@@ -12,7 +13,7 @@ defmodule Mix.Tasks.Nerves.Clean do
   """
 
   use Mix.Task
-  import Mix.Nerves.IO
+  import Mix.Nerves.Bootstrap.IO
 
   @switches [all: :boolean]
 
@@ -23,7 +24,7 @@ defmodule Mix.Tasks.Nerves.Clean do
 
     # Start the Nerves env with the precompiler disabled
     #  so we can clean the package without building it.
-    Mix.Tasks.Nerves.Env.run(["--disable"])
+    Mix.Tasks.Nerves.Bootstrap.Env.run(["--disable"])
 
     packages =
       case packages do

--- a/lib/mix/tasks/nerves/bootstrap.deps.get.ex
+++ b/lib/mix/tasks/nerves/bootstrap.deps.get.ex
@@ -1,20 +1,20 @@
-defmodule Mix.Tasks.Nerves.Deps.Get do
-  @moduledoc false
+defmodule Mix.Tasks.Nerves.Bootstrap.Deps.Get do
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
   use Mix.Task
 
-  import Mix.Nerves.IO
+  import Mix.Nerves.Bootstrap.IO
 
   @impl Mix.Task
   def run(_argv) do
-    debug_info("Nerves.Deps.Get Start")
+    debug_info("Nerves.Bootstrap.Deps.Get Start")
     nerves_env_info()
     # We want to start Nerves.Env so it compiles `nerves`
     # but pass --disable to prevent it from compiling
     # the system and toolchain during this time.
-    Mix.Tasks.Nerves.Env.run(["--disable"])
+    Mix.Tasks.Nerves.Bootstrap.Env.run(["--disable"])
     Mix.Task.run("nerves.artifact.get", [])
     Nerves.Bootstrap.check_for_update()
 
-    debug_info("Nerves.Deps.Get End")
+    debug_info("Nerves.Bootstrap.Deps.Get End")
   end
 end

--- a/lib/mix/tasks/nerves/bootstrap.env.ex
+++ b/lib/mix/tasks/nerves/bootstrap.env.ex
@@ -1,7 +1,7 @@
-defmodule Mix.Tasks.Nerves.Env do
-  @moduledoc false
+defmodule Mix.Tasks.Nerves.Bootstrap.Env do
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
   use Mix.Task
-  import Mix.Nerves.IO
+  import Mix.Nerves.Bootstrap.IO
 
   @switches [info: :boolean, disable: :boolean]
 
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.Nerves.Env do
       packages -> Enum.each(packages, &print_pkg/1)
     end
 
-    Mix.Tasks.Nerves.Loadpaths.run([])
+    Mix.Tasks.Nerves.Bootstrap.Loadpaths.run([])
   end
 
   defp print_pkg(pkg) do

--- a/lib/mix/tasks/nerves/bootstrap.ex
+++ b/lib/mix/tasks/nerves/bootstrap.ex
@@ -1,0 +1,59 @@
+defmodule Mix.Tasks.Nerves.Bootstrap do
+  @moduledoc """
+  Bootstrap Nerves tooling into the current Mix tooling
+
+  The Nerves lib contains all the tasks and tooling for setting up the
+  environment needed to use the Nerves project. However, some of that
+  tooling needs to be injected early in the build process before everything
+  is compiled.
+
+  The purpose of this task is to ensure the Nerves integration is compiled
+  first and available to be injected into the Mix tooling since Nerves.Bootstrap
+  is available as an archive. (i.e. this is like having `:nerves` as a
+  dependency of this archive even though archives do not allow traditional
+  dependencies)
+
+  It is not intended to be run manually
+  """
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_args) do
+    debug("load nerves START")
+
+    unless Code.ensure_loaded?(Nerves.Env) do
+      _ = Mix.Tasks.Deps.Loadpaths.run(["--no-compile"])
+
+      check_nerves_version!()
+      Mix.Tasks.Deps.Compile.run(["nerves", "--include-children"])
+    end
+
+    Nerves.Bootstrap.check_for_update()
+
+    debug("load nerves END")
+  end
+
+  defp check_nerves_version!() do
+    version = Nerves.Bootstrap.nerves_version()
+
+    if Version.match?(version, "< 1.8.0") do
+      Mix.raise("""
+      The Nerves mix integration requires `:nerves >= 1.8.0`. Got: #{version}
+
+      You can fix this by updating to the latest version of `:nerves`:
+
+        mix deps.update nerves
+
+      Or by downgrading the Nerves mix intergation with:
+
+        mix archive.install hex nerves_bootstrap 1.10.6
+      """)
+    end
+  end
+
+  defp debug(msg) do
+    if System.get_env("NERVES_DEBUG") == "1" do
+      Mix.shell().info([:inverse, "|nerves_boostrap| #{msg}", :reset])
+    end
+  end
+end

--- a/lib/mix/tasks/nerves/bootstrap.loadpaths.ex
+++ b/lib/mix/tasks/nerves/bootstrap.loadpaths.ex
@@ -1,7 +1,7 @@
-defmodule Mix.Tasks.Nerves.Loadpaths do
-  @moduledoc false
+defmodule Mix.Tasks.Nerves.Bootstrap.Loadpaths do
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
   use Mix.Task
-  import Mix.Nerves.IO
+  import Mix.Nerves.Bootstrap.IO
 
   @impl Mix.Task
   def run(_args) do
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
         true ->
           try do
             nerves_env_info()
-            Mix.Task.run("nerves.env", [])
+            Mix.Task.run("nerves.bootstrap.env", [])
             Nerves.Env.bootstrap()
             clear_deps_cache()
             env_info()
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
           end
 
         false ->
-          Mix.Task.run("nerves.precompile")
+          Mix.Task.run("nerves.bootstrap.precompile")
       end
 
       debug_info("Loadpaths End")

--- a/lib/mix/tasks/nerves/bootstrap.precompile.ex
+++ b/lib/mix/tasks/nerves/bootstrap.precompile.ex
@@ -1,7 +1,7 @@
-defmodule Mix.Tasks.Nerves.Precompile do
-  @moduledoc false
+defmodule Mix.Tasks.Nerves.Bootstrap.Precompile do
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
   use Mix.Task
-  import Mix.Nerves.IO
+  import Mix.Nerves.Bootstrap.IO
 
   @switches [loadpaths: :boolean]
 
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Nerves.Precompile do
 
       {opts, _, _} = OptionParser.parse(args, switches: @switches)
 
-      Mix.Tasks.Nerves.Env.run([])
+      Mix.Tasks.Nerves.Bootstrap.Env.run([])
 
       {app, deps} =
         Nerves.Env.packages()
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Nerves.Precompile do
 
       System.put_env("NERVES_PRECOMPILE", "0")
 
-      if opts[:loadpaths] != false, do: Mix.Task.rerun("nerves.loadpaths")
+      if opts[:loadpaths] != false, do: Mix.Task.rerun("nerves.bootstrap.loadpaths")
     end
 
     debug_info("Precompile End")

--- a/lib/mix/tasks/nerves/bootstrap.system.shell.ex
+++ b/lib/mix/tasks/nerves/bootstrap.system.shell.ex
@@ -1,5 +1,6 @@
-defmodule Mix.Tasks.Nerves.System.Shell do
+defmodule Mix.Tasks.Nerves.Bootstrap.System.Shell do
   @shortdoc "Enter a shell to configure a custom system"
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
 
   @moduledoc """
   Open a shell in a system's build directory.

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -17,9 +17,19 @@ defmodule Nerves.Bootstrap do
   def version(), do: @version
 
   @doc """
+  Read the Nerves dependency version of the bootstrapped project
+  """
+  @spec nerves_version() :: String.t()
+  def nerves_version() do
+    if path = Mix.Project.deps_paths()[:nerves] do
+      Mix.Project.in_project(:nerves, path, fn _ -> Mix.Project.config()[:version] end)
+    end
+  end
+
+  @doc """
   Add the required Nerves bootstrap aliases to the existing ones
   """
-  defdelegate add_aliases(aliases), to: Nerves.Bootstrap.Aliases
+  defdelegate add_aliases(aliases, nerves_ver \\ nil), to: Nerves.Bootstrap.Aliases
 
   @doc """
   Check the nerves_bootstrap updates from hex
@@ -44,7 +54,7 @@ defmodule Nerves.Bootstrap do
         :ok
 
       latest_version ->
-        render_update_message(current_version, latest_version)
+        render_update_message(current_version, latest_version, nerves_version())
     end
   rescue
     _e -> :ok
@@ -59,8 +69,8 @@ defmodule Nerves.Bootstrap do
     |> List.first()
   end
 
-  @spec render_update_message(any, %{:pre => any, optional(any) => any}) :: :ok
-  def render_update_message(current_version, %{pre: pre} = latest_version) do
+  @spec render_update_message(any, %{:pre => any, optional(any) => any}, String.t() | nil) :: :ok
+  def render_update_message(current_version, %{pre: pre} = latest_version, nerves_ver \\ nil) do
     message =
       "A new version of Nerves bootstrap is available(#{current_version} < #{latest_version}), " <>
         if pre == [] do
@@ -76,6 +86,22 @@ defmodule Nerves.Bootstrap do
             mix archive.install hex nerves_bootstrap #{latest_version}
           """
         end
+
+    message =
+      if nerves_ver && Version.match?(nerves_ver, "< 1.8.0"),
+        do:
+          message <>
+            """
+
+            It is recommended to update your `:nerves` version also as this update
+            utilizes updates and improvements from `:nerves >= 1.8.0`.
+            (You currently have #{nerves_ver})
+
+              mix deps.update nerves
+
+            However, this is backwards compatible if you cannot update `:nerves` at this time.
+            """,
+        else: message
 
     Mix.shell().info([:yellow, message, :reset])
   end

--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -1,15 +1,20 @@
 defmodule Nerves.Bootstrap.Aliases do
   @moduledoc false
 
+  @type instruction :: (list() -> list())
+
   @spec init() :: :ok
   def init() do
     with %{} <- Mix.ProjectStack.peek(),
+         nerves_ver = Nerves.Bootstrap.nerves_version(),
          %{name: name, config: config, file: file} <- Mix.ProjectStack.pop(),
          nil <- Mix.ProjectStack.peek() do
+      instructions = instructions_for_nerves_version(nerves_ver)
+
       adjusted_config =
         config
-        |> update_host_config()
-        |> update_target_config(Nerves.Bootstrap.mix_target())
+        |> update_host_config(instructions.host)
+        |> update_target_config(Nerves.Bootstrap.mix_target(), instructions.target)
 
       :ok = Mix.ProjectStack.push(name, adjusted_config, file)
     else
@@ -19,24 +24,58 @@ defmodule Nerves.Bootstrap.Aliases do
     end
   end
 
-  defp update_host_config(config) do
-    update_in(config, [:aliases], &add_host_aliases(&1))
+  defp instructions_for_nerves_version(ver) do
+    if not is_nil(ver) and Version.match?(ver, "< 1.8.0") do
+      %{
+        host: [
+          &append(&1, "deps.get", "nerves.bootstrap.deps.get"),
+          fn a -> replace(a, "deps.update", &__MODULE__.old_deps_update/1) end,
+          &replace(&1, "nerves.clean", "nerves.bootstrap.clean"),
+          &replace(&1, "nerves.system.shell", "nerves.bootstrap.system.shell")
+        ],
+        target: [
+          &prepend(&1, "deps.loadpaths", "nerves.bootstrap.loadpaths"),
+          &prepend(&1, "deps.compile", "nerves.bootstrap.loadpaths")
+        ]
+      }
+    else
+      %{
+        host: [
+          &append(&1, "deps.get", "nerves.bootstrap"),
+          &append(&1, "deps.get", "nerves.deps.get"),
+          fn a -> replace(a, "deps.update", &__MODULE__.deps_update/1) end
+        ],
+        target: [
+          &prepend(&1, "deps.loadpaths", "nerves.loadpaths"),
+          &prepend(&1, "deps.loadpaths", "nerves.bootstrap"),
+          &prepend(&1, "deps.compile", "nerves.loadpaths"),
+          &prepend(&1, "deps.compile", "nerves.bootstrap")
+        ]
+      }
+    end
   end
 
-  defp update_target_config(config, :host), do: config
-
-  defp update_target_config(config, _target) do
-    update_in(config, [:aliases], &add_target_aliases(&1))
+  defp update_host_config(config, instructions) do
+    update_in(config, [:aliases], &add_host_aliases(&1, instructions))
   end
 
-  @spec add_aliases(keyword()) :: keyword()
-  def add_aliases(aliases) do
+  defp update_target_config(config, :host, _), do: config
+
+  defp update_target_config(config, _target, instructions) do
+    update_in(config, [:aliases], &add_target_aliases(&1, instructions))
+  end
+
+  @spec add_aliases(keyword(), Version.version() | nil) :: keyword()
+  def add_aliases(aliases, nerves_version \\ nil) do
+    instructions = instructions_for_nerves_version(nerves_version)
+
     aliases
-    |> add_host_aliases()
-    |> add_target_aliases()
+    |> add_host_aliases(instructions.host)
+    |> add_target_aliases(instructions.target)
   end
 
   @spec add_host_aliases(keyword()) :: keyword()
+  @deprecated "Use add_host_aliases/2"
   def add_host_aliases(aliases) do
     aliases
     |> append("deps.get", "nerves.deps.get")
@@ -44,10 +83,22 @@ defmodule Nerves.Bootstrap.Aliases do
   end
 
   @spec add_target_aliases(keyword()) :: keyword()
+  @deprecated "Use add_target_aliases/2"
   def add_target_aliases(aliases) do
     aliases
     |> prepend("deps.loadpaths", "nerves.loadpaths")
     |> prepend("deps.compile", "nerves.loadpaths")
+    |> replace("run", &Nerves.Bootstrap.Aliases.run/1)
+  end
+
+  @spec add_host_aliases(keyword(), [instruction()]) :: keyword()
+  def add_host_aliases(aliases, instructions) do
+    Enum.reduce(instructions, aliases, & &1.(&2))
+  end
+
+  @spec add_target_aliases(keyword(), [instruction()]) :: keyword()
+  def add_target_aliases(aliases, instructions) do
+    Enum.reduce(instructions, aliases, & &1.(&2))
     |> replace("run", &Nerves.Bootstrap.Aliases.run/1)
   end
 
@@ -58,7 +109,7 @@ defmodule Nerves.Bootstrap.Aliases do
         Mix.Tasks.Run.run(args)
 
       target ->
-        Mix.Nerves.IO.shell_warn("""
+        Mix.Nerves.Bootstrap.IO.shell_warn("""
         You are trying to run code compiled for #{target}
         on your host. Please unset MIX_TARGET to run in host mode.
         """)
@@ -67,8 +118,19 @@ defmodule Nerves.Bootstrap.Aliases do
 
   @spec deps_update([String.t()]) :: :ok
   def deps_update(args) do
+    Mix.Nerves.Bootstrap.IO.debug_info("deps.update start")
     Mix.Tasks.Deps.Update.run(args)
-    Mix.Tasks.Nerves.Deps.Get.run([])
+    Mix.Task.run("nerves.bootstrap", [])
+    Mix.Task.run("nerves.deps.get", [])
+    Mix.Nerves.Bootstrap.IO.debug_info("deps.update end")
+  end
+
+  @spec old_deps_update([String.t()]) :: :ok
+  def old_deps_update(args) do
+    Mix.Nerves.Bootstrap.IO.debug_info("deps.update start")
+    Mix.Tasks.Deps.Update.run(args)
+    Mix.Tasks.Nerves.Bootstrap.Deps.Get.run([])
+    Mix.Nerves.Bootstrap.IO.debug_info("deps.update end")
   end
 
   defp append(aliases, a, na) do

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,8 @@ defmodule Nerves.Bootstrap.MixProject do
       install: [
         "archive.build -o nerves_bootstrap.ez",
         "archive.install nerves_bootstrap.ez --force"
-      ]
+      ],
+      wat: ["cmd 'echo HEYEYEYEYEYE'"]
     ]
   end
 


### PR DESCRIPTION
After some discussion, this is an alternate proposal to #225 which keeps backwards compatibility but allows use to move forward developing and maintaining the tooling in `:nerves`

`Nerves.Bootstrap` and `Nerves` share a lot of code back and forth
which makes things a little hard to maintain and causes confusion
when trying to following the mix integration with Nerves.

This changes things to move all the tasks to `:nerves` and only use
Nerves.Bootstrap to provided the Nerves project generator and do
the initial loading of `:nerves` into the current Nerves project
being built.

From there, all of the work and heavy lifting with be done with
`:nerves` and maintained there

It does leave the original tasks in this lib under new module names
and will correctly assign aliseses based on the nerves version detected
so things stay backwards compatible for a while