### PR TITLE
Move core tooling to :nerves (moar backwards compatible)

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,15 +1,15 @@
 # Run `mix dialyzer --format short` for strings
 [
-  {"lib/mix/tasks/nerves/clean.ex:32:unknown_function Function Nerves.Env.packages/0 does not exist."},
-  {"lib/mix/tasks/nerves/clean.ex:48:unknown_function Function Nerves.Env.package/1 does not exist."},
-  {"lib/mix/tasks/nerves/clean.ex:52:unknown_function Function Nerves.Env.clean/1 does not exist."},
-  {"lib/mix/tasks/nerves/env.ex:31:unknown_function Function Nerves.Env.start/0 does not exist."},
-  {"lib/mix/tasks/nerves/env.ex:40:unknown_function Function Nerves.Env.packages/0 does not exist."},
-  {"lib/mix/tasks/nerves/loadpaths.ex:16:unknown_function Function Nerves.Env.bootstrap/0 does not exist."},
-  {"lib/mix/tasks/nerves/precompile.ex:25:unknown_function Function Nerves.Env.packages/0 does not exist."},
-  {"lib/mix/tasks/nerves/precompile.ex:57:unknown_function Function Nerves.Artifact.expand_sites/1 does not exist."},
-  {"lib/mix/tasks/nerves/precompile.ex:58:unknown_function Function Nerves.Artifact.stale?/1 does not exist."},
-  {"lib/mix/tasks/nerves/system.shell.ex:62:unknown_function Function Nerves.Env.system/0 does not exist."},
-  {"lib/nerves_bootstrap.ex:29:unknown_function Function Hex.start/0 does not exist."},
-  {"lib/nerves_bootstrap.ex:30:unknown_function Function Hex.API.Package.get/2 does not exist."}
+  {"lib/attic/clean.ex:33:unknown_function Function Nerves.Env.packages/0 does not exist."},
+  {"lib/attic/clean.ex:49:unknown_function Function Nerves.Env.package/1 does not exist."},
+  {"lib/attic/clean.ex:53:unknown_function Function Nerves.Env.clean/1 does not exist."},
+  {"lib/attic/env.ex:29:unknown_function Function Nerves.Env.start/0 does not exist."},
+  {"lib/attic/env.ex:38:unknown_function Function Nerves.Env.packages/0 does not exist."},
+  {"lib/attic/loadpaths.ex:16:unknown_function Function Nerves.Env.bootstrap/0 does not exist."},
+  {"lib/attic/precompile.ex:25:unknown_function Function Nerves.Env.packages/0 does not exist."},
+  {"lib/attic/precompile.ex:57:unknown_function Function Nerves.Artifact.expand_sites/1 does not exist."},
+  {"lib/attic/precompile.ex:58:unknown_function Function Nerves.Artifact.stale?/1 does not exist."},
+  {"lib/attic/system.shell.ex:63:unknown_function Function Nerves.Env.system/0 does not exist."},
+  {"lib/nerves_bootstrap.ex:39:unknown_function Function Hex.start/0 does not exist."},
+  {"lib/nerves_bootstrap.ex:40:unknown_function Function Hex.API.Package.get/2 does not exist."}
 ]

--- a/README.md
+++ b/README.md
@@ -6,44 +6,6 @@
 Nerves.Bootstrap is an Elixir archive that brings Nerves support to Elixir's Mix
 build tool and provides a new project generator, `mix nerves.new`.
 
-Nerves.Bootstrap does this by rebuilding aliased tasks after the inital config
-is loaded in to inject needed Nerves task into the build process where needed.
-To do this, you must start Nerves.Bootstrap in the `config/config.exs` of your
-Nerves project:
-
-```elixir
-# config/config.exs
-import Config
-
-Applcation.start(:nerves_bootstrap)
-```
-
-The following task aliases will be adjusted whenever Nerves.Bootstrap is used:
-
-```elixir
-[
-  "deps.get": ["deps.get", "nerves.bootstrap", "nerves.deps.get"],
-  "deps.update": ["deps.update", "nerves.bootstrap", "nerves.deps.get"]
-]
-```
-
-When `MIX_TARGET` is set, the following will also be included:
-
-```elixir
-[
-  "deps.loadpaths": ["nerves.bootstrap", "nerves.loadpaths", "deps.loadpaths"],
-  "deps.compile": ["nerves.bootstrap", "nerves.loadpaths", "deps.compile"],
-  # This is just helper to prevent trying to run tasks on host that were
-  # compiled for a target
-  run: [Nerves.Bootstrap.Aliases.run/1]
-]
-```
-
-Nerves.Bootstrap only defines the aliases since the only way to inject tasks so
-early in the Mix process is via an archive. However, the tooling and tasks are
-defined and maintained in the [`Nerves`](https://github.com/nerves-project/nerves)
-library.
-
 We recommend reading the [Nerves Installation
 Guide](https://hexdocs.pm/nerves/installation.html) for installing and using
 Nerves. Read on for details specific to Nerves.Bootstrap.
@@ -119,6 +81,52 @@ mix nerves.new my_new_nerves_project --no-nerves-pack
 
 This task checks [hex.pm](https://hex.pm/packages/nerves_bootstrap) for updates
 to the `nerves_bootstrap` archive. If one exists, you'll be prompted to update.
+
+## Integration with your project
+
+Nerves.Bootstrap injects Nerves-specific build tasks into the `mix` build process via
+an `Application.start/1` call in your project's `config.exs`. If you use `mix
+nerves.new`, your project will be created with these lines and no additional
+work is needed.
+
+```elixir
+# config/config.exs
+import Config
+
+Application.start(:nerves_bootstrap)
+```
+
+## Internals
+
+Nerves.Bootstrap uses Mix aliases to hook into Mix build steps.
+
+Aliases vary based on whether you are compiling for your host or your target
+device. For host builds, Nerves.Bootstrap injects the following tasks to add
+support for downloading pre-compiled archives.
+
+```elixir
+[
+  "deps.get": ["deps.get", "nerves.bootstrap", "nerves.deps.get"],
+  "deps.update": ["deps.update", "nerves.bootstrap", "nerves.deps.get"]
+]
+```
+
+When `MIX_TARGET` is set, Nerves.Bootstrap injects the following additional
+tasks to support cross-compilation and firmware creation:
+
+```elixir
+[
+  "deps.loadpaths": ["nerves.bootstrap", "nerves.loadpaths", "deps.loadpaths"],
+  "deps.compile": ["nerves.bootstrap", "nerves.loadpaths", "deps.compile"],
+  # This is just helper to prevent trying to run tasks on host that were
+  # compiled for a target
+  run: [Nerves.Bootstrap.Aliases.run/1]
+]
+```
+
+Nerves.Bootstrap provides only minimal code to inject the Nerves tooling. The
+main Nerves tooling is the [`Nerves`](https://github.com/nerves-project/nerves)
+library.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,45 @@
 [![Hex.pm](https://img.shields.io/hexpm/v/nerves_bootstrap.svg)](https://hex.pm/packages/nerves_bootstrap)
 
 Nerves.Bootstrap is an Elixir archive that brings Nerves support to Elixir's Mix
-build tool. It also provides a new project generator, `mix nerves.new`.
+build tool and provides a new project generator, `mix nerves.new`.
+
+Nerves.Bootstrap does this by rebuilding aliased tasks after the inital config
+is loaded in to inject needed Nerves task into the build process where needed.
+To do this, you must start Nerves.Bootstrap in the `config/config.exs` of your
+Nerves project:
+
+```elixir
+# config/config.exs
+import Config
+
+Applcation.start(:nerves_bootstrap)
+```
+
+The following task aliases will be adjusted whenever Nerves.Bootstrap is used:
+
+```elixir
+[
+  "deps.get": ["deps.get", "nerves.bootstrap", "nerves.deps.get"],
+  "deps.update": ["deps.update", "nerves.bootstrap", "nerves.deps.get"]
+]
+```
+
+When `MIX_TARGET` is set, the following will also be included:
+
+```elixir
+[
+  "deps.loadpaths": ["nerves.bootstrap", "nerves.loadpaths", "deps.loadpaths"],
+  "deps.compile": ["nerves.bootstrap", "nerves.loadpaths", "deps.compile"],
+  # This is just helper to prevent trying to run tasks on host that were
+  # compiled for a target
+  run: [Nerves.Bootstrap.Aliases.run/1]
+]
+```
+
+Nerves.Bootstrap only defines the aliases since the only way to inject tasks so
+early in the Mix process is via an archive. However, the tooling and tasks are
+defined and maintained in the [`Nerves`](https://github.com/nerves-project/nerves)
+library.
 
 We recommend reading the [Nerves Installation
 Guide](https://hexdocs.pm/nerves/installation.html) for installing and using
@@ -81,34 +119,6 @@ mix nerves.new my_new_nerves_project --no-nerves-pack
 
 This task checks [hex.pm](https://hex.pm/packages/nerves_bootstrap) for updates
 to the `nerves_bootstrap` archive. If one exists, you'll be prompted to update.
-
-### mix nerves.clean
-
-This task cleans dependencies in a similar way to `mix deps.clean`, but it
-additionally erases downloaded artifacts and build products from Nerves
-packages.
-
-### mix nerves.system.shell
-
-This task starts up a shell in an environment suitable for modifying Nerves
-systems. This allows you to interact with `make menuconfig` in Buildroot,
-manually enable and build C libraries, the Linux kernel, bootloaders, and more.
-Depending on your system, it may also start up Docker. See the Nerves
-documentation for usage.
-
-## Building systems and toolchains
-
-Nerves expects systems and toolchains to include a URL to a precompiled build
-artifact. Building these dependencies can take hours in some cases, so Nerves
-will not automatically compile them. It can do this, though, and depending on
-your computer, it may even start up Docker to do the builds.
-
-To force compilation to happen, add a `:nerves` option for the desired package
-in your top level project:
-
-```elixir
-  {:nerves_system_rpi0, "~> 1.5", nerves: [compile: true]}
-```
 
 ## Local development
 

--- a/lib/attic/clean.ex
+++ b/lib/attic/clean.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Nerves.Clean do
   @shortdoc "Cleans dependencies and build artifacts"
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
 
   @moduledoc """
   Cleans dependencies and build artifacts

--- a/lib/attic/deps.get.ex
+++ b/lib/attic/deps.get.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Nerves.Deps.Get do
-  @moduledoc false
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
   use Mix.Task
 
   import Mix.Nerves.IO

--- a/lib/attic/env.ex
+++ b/lib/attic/env.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Nerves.Env do
-  @moduledoc false
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
   use Mix.Task
   import Mix.Nerves.IO
 
@@ -22,11 +22,9 @@ defmodule Mix.Tasks.Nerves.Env do
       System.delete_env("NERVES_ENV_DISABLED")
     end
 
-    unless Code.ensure_loaded?(Nerves.Env) do
-      _ = Mix.Tasks.Deps.Loadpaths.run(["--no-compile"])
-
-      Mix.Tasks.Deps.Compile.run(["nerves", "--include-children"])
-    end
+    # Ensure Nerves is compiled and bootstrapped in
+    # If it was already run, this is a noop
+    Mix.Task.run("nerves.bootstrap")
 
     Nerves.Env.start()
     debug_info("Env End")

--- a/lib/attic/io.ex
+++ b/lib/attic/io.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Nerves.IO do
-  @moduledoc false
+  @moduledoc deprecated: "IO from :nerves should be used instead"
   @app Mix.Project.config()[:app]
 
   @spec debug_info(String.t(), String.t(), atom()) :: :ok

--- a/lib/attic/loadpaths.ex
+++ b/lib/attic/loadpaths.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Nerves.Loadpaths do
-  @moduledoc false
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
   use Mix.Task
   import Mix.Nerves.IO
 

--- a/lib/attic/precompile.ex
+++ b/lib/attic/precompile.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Nerves.Precompile do
-  @moduledoc false
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
   use Mix.Task
   import Mix.Nerves.IO
 

--- a/lib/attic/system.shell.ex
+++ b/lib/attic/system.shell.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Nerves.System.Shell do
   @shortdoc "Enter a shell to configure a custom system"
+  @moduledoc deprecated: "Tasks from :nerves should be used instead"
 
   @moduledoc """
   Open a shell in a system's build directory.

--- a/lib/mix/tasks/nerves/bootstrap.ex
+++ b/lib/mix/tasks/nerves/bootstrap.ex
@@ -1,0 +1,61 @@
+defmodule Mix.Tasks.Nerves.Bootstrap do
+  @moduledoc """
+  Bootstrap Nerves tooling into the current Mix tooling
+
+  The Nerves lib contains all the tasks and tooling for setting up the
+  environment needed to use the Nerves project. However, some of that
+  tooling needs to be injected early in the build process before everything
+  is compiled.
+
+  The purpose of this task is to ensure the Nerves integration is compiled
+  first and available to be injected into the Mix tooling since Nerves.Bootstrap
+  is available as an archive. (i.e. this is like having `:nerves` as a
+  dependency of this archive even though archives do not allow traditional
+  dependencies)
+
+  It is not intended to be run manually
+  """
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_args) do
+    debug("load nerves START")
+
+    unless Code.ensure_loaded?(Nerves.Env) do
+      _ = Mix.Tasks.Deps.Loadpaths.run(["--no-compile"])
+
+      # Nerves.Bootstrap used to manage all the Nerves mix tasks and continues
+      # to define them for backwards compatibilty. But the mix tasks were moved
+      # to Nerves in new versions to be maintained there. So if the newer Nerves
+      # version is being used, then there will be lots of warnings about modules
+      # from Nerves.Bootstrap being redefined in Nerves, so we opt to suppress
+      # them only while we compile Nerves, and then set back to original option
+      {ignore?, prev} = get_ignore_opts()
+      Code.put_compiler_option(:ignore_module_conflict, ignore?)
+      Mix.Tasks.Deps.Compile.run(["nerves", "--include-children"])
+      Code.put_compiler_option(:ignore_module_conflict, prev)
+    end
+
+    Nerves.Bootstrap.check_for_update()
+
+    debug("load nerves END")
+  end
+
+  defp get_ignore_opts() do
+    version = Nerves.Bootstrap.nerves_version()
+    prev = Code.get_compiler_option(:ignore_module_conflict) || false
+
+    if version && Version.match?(version, "> 1.7.16") do
+      debug("ignoring module conflict warnings with Nerves")
+      {true, prev}
+    else
+      {false, false}
+    end
+  end
+
+  defp debug(msg) do
+    if System.get_env("NERVES_DEBUG") == "1" do
+      Mix.shell().info([:inverse, "|nerves_boostrap| #{msg}", :reset])
+    end
+  end
+end

--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -39,6 +39,7 @@ defmodule Nerves.Bootstrap.Aliases do
   @spec add_host_aliases(keyword()) :: keyword()
   def add_host_aliases(aliases) do
     aliases
+    |> append("deps.get", "nerves.bootstrap")
     |> append("deps.get", "nerves.deps.get")
     |> replace("deps.update", &Nerves.Bootstrap.Aliases.deps_update/1)
   end
@@ -47,7 +48,9 @@ defmodule Nerves.Bootstrap.Aliases do
   def add_target_aliases(aliases) do
     aliases
     |> prepend("deps.loadpaths", "nerves.loadpaths")
+    |> prepend("deps.loadpaths", "nerves.bootstrap")
     |> prepend("deps.compile", "nerves.loadpaths")
+    |> prepend("deps.compile", "nerves.bootstrap")
     |> replace("run", &Nerves.Bootstrap.Aliases.run/1)
   end
 
@@ -58,17 +61,20 @@ defmodule Nerves.Bootstrap.Aliases do
         Mix.Tasks.Run.run(args)
 
       target ->
-        Mix.Nerves.IO.shell_warn("""
+        msg = """
         You are trying to run code compiled for #{target}
         on your host. Please unset MIX_TARGET to run in host mode.
-        """)
+        """
+
+        Mix.shell().error([:inverse, :red, "|nerves_bootstrap| ", msg, :reset])
     end
   end
 
   @spec deps_update([String.t()]) :: :ok
   def deps_update(args) do
     Mix.Tasks.Deps.Update.run(args)
-    Mix.Tasks.Nerves.Deps.Get.run([])
+    Mix.Task.run("nerves.bootstrap", [])
+    Mix.Task.run("nerves.deps.get", [])
   end
 
   defp append(aliases, a, na) do

--- a/test/nerves_bootstrap_test.exs
+++ b/test/nerves_bootstrap_test.exs
@@ -2,10 +2,10 @@ defmodule Nerves.BootstrapTest do
   use ExUnit.Case
 
   test "aliases are injected properly" do
-    deps_loadpaths = ["nerves.loadpaths", "deps.loadpaths"]
-    deps_get = ["deps.get", "nerves.deps.get"]
+    deps_loadpaths = ["nerves.bootstrap", "nerves.loadpaths", "deps.loadpaths"]
+    deps_get = ["deps.get", "nerves.bootstrap", "nerves.deps.get"]
     deps_update = [&Nerves.Bootstrap.Aliases.deps_update/1]
-    deps_compile = ["nerves.loadpaths", "deps.compile"]
+    deps_compile = ["nerves.bootstrap", "nerves.loadpaths", "deps.compile"]
 
     aliases = Nerves.Bootstrap.add_aliases([])
     assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
@@ -16,8 +16,8 @@ defmodule Nerves.BootstrapTest do
 
   test "custom aliases are maintained" do
     custom_aliases = [
-      "deps.loadpaths": ["custom", "deps.loadpaths"],
-      "deps.get": ["deps.get", "custom"],
+      "deps.loadpaths": ["custom", "nerves.bootstrap", "deps.loadpaths"],
+      "deps.get": ["deps.get", "nerves.bootstrap", "custom"],
       "deps.update": ["custom"],
       custom: ["custom"]
     ]
@@ -25,12 +25,18 @@ defmodule Nerves.BootstrapTest do
     aliases = Nerves.Bootstrap.add_aliases(custom_aliases)
 
     assert Keyword.get(aliases, :"deps.loadpaths") == [
+             "nerves.bootstrap",
              "nerves.loadpaths",
              "custom",
              "deps.loadpaths"
            ]
 
-    assert Keyword.get(aliases, :"deps.get") == ["deps.get", "custom", "nerves.deps.get"]
+    assert Keyword.get(aliases, :"deps.get") == [
+             "deps.get",
+             "custom",
+             "nerves.bootstrap",
+             "nerves.deps.get"
+           ]
 
     assert Keyword.get(aliases, :"deps.update") == [
              "custom",
@@ -41,8 +47,8 @@ defmodule Nerves.BootstrapTest do
   end
 
   test "aliases are dropped if they already exist" do
-    deps_loadpaths = ["nerves.loadpaths", "deps.loadpaths"]
-    deps_get = ["deps.get", "nerves.deps.get"]
+    deps_loadpaths = ["nerves.bootstrap", "nerves.loadpaths", "deps.loadpaths"]
+    deps_get = ["deps.get", "nerves.bootstrap", "nerves.deps.get"]
     deps_update = [&Nerves.Bootstrap.Aliases.deps_update/1]
 
     nerves_aliases = [
@@ -124,5 +130,25 @@ defmodule Nerves.BootstrapTest do
     Nerves.Bootstrap.render_update_message(current_version, latest_version)
     assert_receive {:mix_shell, :info, [message]}
     assert message =~ "mix local.nerves"
+  end
+
+  test "adds message when old nerves version is used" do
+    current_version = Version.parse!("0.8.0")
+    latest_version = Version.parse!("0.8.1")
+    nerves_ver = "1.7.16"
+    Nerves.Bootstrap.render_update_message(current_version, latest_version, nerves_ver)
+
+    assert_receive {:mix_shell, :info, [message]}
+    assert message =~ "It is recommended to update your `:nerves`"
+  end
+
+  test "Does not include nerves message when acceptable version in deps" do
+    current_version = Version.parse!("0.8.0")
+    latest_version = Version.parse!("0.8.1")
+    nerves_ver = "1.8.0"
+    Nerves.Bootstrap.render_update_message(current_version, latest_version, nerves_ver)
+
+    assert_receive {:mix_shell, :info, [message]}
+    refute message =~ "It is recommended to update your `:nerves`"
   end
 end


### PR DESCRIPTION
This is take 3 as an alternative to #225 and #226 

The origianl tasks are left in and moved to the `attic` dir for backwards
compatibility. If this bootstrap is used with the new Nerves, module
redefinition warnings are suppresed during compilation so that new
Nerves can redefine these tasks as needed and it will be transparent
to the user.