### PR TITLE
Add `:grisp2` to the new project generator

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -74,7 +74,8 @@ defmodule Mix.Tasks.Nerves.New do
     {:rpi4, "1.19"},
     {:bbb, "2.14"},
     {:osd32mp1, "0.10"},
-    {:x86_64, "1.19"}
+    {:x86_64, "1.19"},
+    {:grisp2, "0.3"}
   ]
 
   @new [

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -33,6 +33,7 @@ defmodule Nerves.NewTest do
                  "{:nerves_system_osd32mp1, \"~> 0.10\", runtime: false, targets: :osd32mp1"
 
         assert file =~ "{:nerves_system_x86_64, \"~> 1.19\", runtime: false, targets: :x86_64"
+        assert file =~ "{:nerves_system_grisp2, \"~> 0.3\", runtime: false, targets: :grisp2"
       end)
     end)
   end


### PR DESCRIPTION
We now officially support GRiSP2, adding [nerves_system_grisp2](https://github.com/nerves-project/nerves_system_grisp2).

## Changes

* Add `:grisp2` to the new project generator

## Notes

* Latest `nerves_system_grisp2` version is `0.3.0` as of writing: https://hex.pm/packages/nerves_system_grisp2