### PR TITLE
Precompile nerves packages when loading Nerves

### DIFF
--- a/lib/attic/loadpaths.ex
+++ b/lib/attic/loadpaths.ex
@@ -8,21 +8,17 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
     unless System.get_env("NERVES_PRECOMPILE") == "1" do
       debug_info("Loadpaths Start")
 
-      case Code.ensure_loaded?(Nerves.Env) do
-        true ->
-          try do
-            nerves_env_info()
-            Mix.Task.run("nerves.env", [])
-            Nerves.Env.bootstrap()
-            clear_deps_cache()
-            env_info()
-          rescue
-            e ->
-              reraise e, __STACKTRACE__
-          end
+      Mix.Task.run("nerves.precompile", ["--no-loadpaths"])
 
-        false ->
-          Mix.Task.run("nerves.precompile")
+      try do
+        nerves_env_info()
+        Mix.Task.run("nerves.env", [])
+        Nerves.Env.bootstrap()
+        clear_deps_cache()
+        env_info()
+      rescue
+        e ->
+          reraise e, __STACKTRACE__
       end
 
       debug_info("Loadpaths End")


### PR DESCRIPTION
In the old pattern, we would decide that the precompiled pieces of the
tooling were avaialble by checking that `Nerves.Env` module was loaded.
However, with the new tooling, we preemptively load `:nerves` as the
first step so that we can use the tooling there instead of from
Nerves.Bootstrap. This loads `Nerves.Env` and makes these later checks
fail. his means that nerves.loadpaths skips the precompile step, which is
what loads systems, toolchains, and platform into the tooling. This is
crucial because nerves.precompile either resolves an avaialble system
and toolchain to use, or creates an alias as a placeholder to compile
the system to. Without that alias, system compilation fails.

In the new tooling, we skip checking for `Nerves.Env` is loaded and just
run the precompile when we need it. This changes the attic tasks to do
the same thing when running `nerves.loadpaths` so that the right pieces
get added into the tooling stream.