### PR TITLE
Remove :build_embedded option since it's no longer needed

### DIFF
--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -16,7 +16,6 @@ defmodule <%= app_module %>.MixProject do
       config_path: "../../config/config.exs",
       lockfile: "../../mix.lock",<% end %>
       start_permanent: Mix.env() == :prod,
-      build_embedded: true,
       deps: deps(),
       releases: [{@app, release()}],
       preferred_cli_target: [run: :host, test: :host]

--- a/test/nerves_new_test.exs
+++ b/test/nerves_new_test.exs
@@ -141,12 +141,12 @@ defmodule Nerves.NewTest do
     end)
   end
 
-  test "new project sets build_embedded", context do
+  test "new project does not set build_embedded", context do
     in_tmp(context.test, fn ->
       Mix.Tasks.Nerves.New.run([@app_name])
 
       assert_file("#{@app_name}/mix.exs", fn file ->
-        assert file =~ ~r/build_embedded:/
+        refute file =~ ~r/build_embedded:/
       end)
     end)
   end


### PR DESCRIPTION
This option was an early workaround for Makefile projects compiling to a
source priv directory. It was found out that this would always have
problems and that the only fix was to have Makefile projects compile to
the `_build` directory.

The `:build_embedded` option will be removed completely in Elixir 1.15.
