### PR TITLE
Suggest to use `:console` logger backend for :host

### DIFF
--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -20,11 +20,6 @@ config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 
 config :nerves, source_date_epoch: "<%= source_date_epoch %>"
 
-# Use Ringlogger as the logger backend and remove :console.
-# See https://hexdocs.pm/ring_logger/readme.html for more information on
-# configuring ring_logger.
-
-config :logger, backends: [RingLogger]
 
 if Mix.target() == :host do
   import_config "host.exs"

--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -1,5 +1,11 @@
 import Config
 
+# Use Ringlogger as the logger backend and remove :console.
+# See https://hexdocs.pm/ring_logger/readme.html for more information on
+# configuring ring_logger.
+
+config :logger, backends: [RingLogger]
+
 # Use shoehorn to start the main application. See the shoehorn
 # library documentation for more control in ordering how OTP
 # applications are started and handling failures.


### PR DESCRIPTION
I think that it's natural to use :console logger backend when developing Nerves on host machine isn't it?