### PR TITLE
Include the latest Nerves version in a new project's dependencies

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Nerves.New do
                             "#{v.major}.#{v.minor}"
                           )
   @nerves_vsn "1.7.16"
-  @nerves_dep ~s[{:nerves, "~> #{@nerves_vsn} or ~> 1.8.0", runtime: false}]
+  @nerves_dep ~s[{:nerves, "~> #{@nerves_vsn} or ~> 1.8.0 or ~> 1.9.0", runtime: false}]
   @shoehorn_vsn "0.9.1"
   @runtime_vsn "0.13.0"
   @ring_logger_vsn "0.8.5"


### PR DESCRIPTION
I ended up getting an error message about a Nerves dependency mismatch after creating a new project, so this PR adds the latest Nerves minor versions (`1.9.x`) as acceptable dependencies in a new project. I'm also happy to update this if there are any older Nerves versions that should be dropped when starting a new project.