### PR TITLE
Change the erlinit example to be more useful

### DIFF
--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -16,10 +16,8 @@ config :shoehorn, init: [:nerves_runtime<%= if nerves_pack? do %>, :nerves_pack<
 # https://github.com/nerves-project/erlinit/ for more information on
 # configuring erlinit.
 
-config :nerves,
-  erlinit: [
-    hostname_pattern: "nerves-%s"
-  ]
+# Advance the system clock on devices without real-time clocks.
+config :nerves, :erlinit, update_clock: true
 
 # Configure the device for SSH IEx prompt access and firmware updates
 #


### PR DESCRIPTION
The current example would set the hostname in the same as the default
for the official Nerves systems. This could be confusing when changing
the hostname via the much more flexible boardid.conf file.

To keep an erlinit example, change it to use `--update-time` to move 
forward to erlinits release time. On a device without a real-time clock, this 
is a 50 year improvement in the time compared to the default.
