### PR TITLE
Set code_path_choice to strict for minor boot time redunction

### DIFF
--- a/templates/new/rel/vm.args.eex
+++ b/templates/new/rel/vm.args.eex
@@ -24,6 +24,10 @@
 ## See http://erlang.org/doc/system_principles/system_principles.html#code-loading-strategy
 -mode embedded
 
+# Load code as per the boot script since not using archives
+# See https://www.erlang.org/doc/man/init.html#command-line-flags
+-code_path_choice strict
+
 ## Disable scheduler busy wait to reduce idle CPU usage and avoid delaying
 ## other OS processes. See http://erlang.org/doc/man/erl.html#+sbwt
 +sbwt none


### PR DESCRIPTION
This flag avoids unnecessary path searches that are used by archives.
See the docs in the comment for more details. Thanks to Jose Valim for
finding this.
