### PR TITLE
Place config files correctly in umbrella app.

### DIFF
--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -87,7 +87,7 @@ defmodule Mix.Tasks.Nerves.New do
   @new_umbrella [
     {:eex, "new/config/host.exs", "../../config/host.exs"},
     {:eex, "new/config/target.exs", "../../config/target.exs"},
-    {:append, "new/config/config_umbrella.exs", "../../config/config.exs"}
+    {:append_render, "new/config/config_umbrella.exs", "../../config/config.exs"}
   ]
 
   @new_common [
@@ -368,6 +368,10 @@ defmodule Mix.Tasks.Nerves.New do
 
         :append ->
           append_to(Path.dirname(target), Path.basename(target), render(source))
+
+        :append_render ->
+          contents = EEx.eval_string(render(source), binding, file: source, trim: false)
+          append_to(Path.dirname(target), Path.basename(target), contents)
 
         :eex ->
           contents = EEx.eval_string(render(source), binding, file: source, trim: false)

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -79,9 +79,18 @@ defmodule Mix.Tasks.Nerves.New do
   ]
 
   @new [
-    {:eex, "new/config/config.exs", "config/config.exs"},
     {:eex, "new/config/host.exs", "config/host.exs"},
     {:eex, "new/config/target.exs", "config/target.exs"},
+    {:eex, "new/config/config.exs", "config/config.exs"}
+  ]
+
+  @new_umbrella [
+    {:eex, "new/config/host.exs", "../../config/host.exs"},
+    {:eex, "new/config/target.exs", "../../config/target.exs"},
+    {:append, "new/config/config_umbrella.exs", "../../config/config.exs"}
+  ]
+
+  @new_common [
     {:eex, "new/lib/app_name.ex", "lib/app_name.ex"},
     {:eex, "new/lib/app_name/application.ex", "lib/app_name/application.ex"},
     {:eex, "new/test/test_helper.exs", "test/test_helper.exs"},
@@ -100,7 +109,7 @@ defmodule Mix.Tasks.Nerves.New do
   # Embed all defined templates
   root = Path.expand("../../../../templates", __DIR__)
 
-  for {format, source, _} <- @new do
+  for {format, source, _} <- @new ++ @new_common ++ @new_umbrella do
     unless format == :keep do
       @external_resource Path.join(root, source)
       defp render(unquote(source)), do: unquote(File.read!(Path.join(root, source)))
@@ -214,7 +223,7 @@ defmodule Mix.Tasks.Nerves.New do
       source_date_epoch: source_date_epoch
     ]
 
-    copy_from(path, binding, @new)
+    copy_from(path, binding, get_mappings(in_umbrella?))
     # Parallel installs
     install? = Mix.shell().yes?("\nFetch and install dependencies?")
 
@@ -387,4 +396,7 @@ defmodule Mix.Tasks.Nerves.New do
   defp generate_source_date_epoch() do
     DateTime.utc_now() |> DateTime.to_unix()
   end
+
+  defp get_mappings(true), do: @new_common ++ @new_umbrella
+  defp get_mappings(false), do: @new_common ++ @new
 end

--- a/templates/new/config/config_umbrella.exs
+++ b/templates/new/config/config_umbrella.exs
@@ -1,0 +1,25 @@
+# This file is responsible for configuring your application and its
+# dependencies.
+#
+
+# Enable the Nerves integration with Mix
+Application.start(:nerves_bootstrap)
+
+config :<%= app_name %>, target: Mix.target()
+
+# Customize non-Elixir parts of the firmware. See
+# https://hexdocs.pm/nerves/advanced-configuration.html for details.
+
+config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
+
+# Set the SOURCE_DATE_EPOCH date for reproducible builds.
+# See https://reproducible-builds.org/docs/source-date-epoch/ for more information
+
+config :nerves, source_date_epoch: "<%= source_date_epoch %>"
+
+
+if Mix.target() == :host do
+  import_config "host.exs"
+else
+  import_config "target.exs"
+end

--- a/templates/new/config/config_umbrella.exs
+++ b/templates/new/config/config_umbrella.exs
@@ -2,21 +2,21 @@
 # dependencies.
 #
 
-# Enable the Nerves integration with Mix
-Application.start(:nerves_bootstrap)
+if Mix.target() != :host do
+  # Enable the Nerves integration with Mix
+  Application.start(:nerves_bootstrap)
 
-config :<%= app_name %>, target: Mix.target()
+  config :<%= app_name %>, target: Mix.target()
+  # Customize non-Elixir parts of the firmware. See
+  # https://hexdocs.pm/nerves/advanced-configuration.html for details.
 
-# Customize non-Elixir parts of the firmware. See
-# https://hexdocs.pm/nerves/advanced-configuration.html for details.
+  config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 
-config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
+  # Set the SOURCE_DATE_EPOCH date for reproducible builds.
+  # See https://reproducible-builds.org/docs/source-date-epoch/ for more information
 
-# Set the SOURCE_DATE_EPOCH date for reproducible builds.
-# See https://reproducible-builds.org/docs/source-date-epoch/ for more information
-
-config :nerves, source_date_epoch: "<%= source_date_epoch %>"
-
+  config :nerves, source_date_epoch: "<%= source_date_epoch %>"
+end
 
 if Mix.target() == :host do
   import_config "host.exs"


### PR DESCRIPTION
WHen adding a Nerves app to my umbrella app I noticed that the project wasn't configured correctly.

The mix.exs file will reference the config files from the umbrella root, but the Nerves app config files aren't merged/moved. So it fails silently as in the app will still compile and seem ok, but the target.exs and host.exs are never invoked.

Let me know if this isn't they way you wan to fix it and I'll change things!