### PR TITLE
Adjust `:nerves_runtime` to be available on host

### DIFF
--- a/templates/new/config/host.exs
+++ b/templates/new/config/host.exs
@@ -1,3 +1,21 @@
 import Config
 
 # Add configuration that is only needed when running on the host here.
+
+config :nerves_runtime,
+  kv_backend:
+    {Nerves.Runtime.KVBackend.InMemory,
+     contents: %{
+       # The KV store on Nerves systems is typically read from UBoot-env, but
+       # this allows us to use a pre-populated InMemory store when running on
+       # host for development and testing.
+       #
+       # https://hexdocs.pm/nerves_runtime/readme.html#using-nerves_runtime-in-tests
+       # https://hexdocs.pm/nerves_runtime/readme.html#nerves-system-and-firmware-metadata
+
+       "nerves_fw_active" => "a",
+       "a.nerves_fw_architecture" => "generic"
+       "a.nerves_fw_description" => "N/A",
+       "a.nerves_fw_platform" => "host",
+       "a.nerves_fw_version" => "0.0.0"
+     }}

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -39,8 +39,11 @@ defmodule <%= app_module %>.MixProject do
       {:ring_logger, "~> <%= ring_logger_vsn %>"},
       {:toolshed, "~> <%= toolshed_vsn %>"},
 
+      # Allow Nerves.Runtime on host to support development, testing and CI.
+      # See config/host.exs for usage.
+      {:nerves_runtime, "~> <%= runtime_vsn %>"},<%= if nerves_pack? do %>
+
       # Dependencies for all targets except :host
-      {:nerves_runtime, "~> <%= runtime_vsn %>", targets: @all_targets},<%= if nerves_pack? do %>
       {:nerves_pack, "~> <%= nerves_pack_vsn %>", targets: @all_targets},<% end %>
 
       # Dependencies for specific targets


### PR DESCRIPTION
This is to help promote improved development and testing patterns when building Nerves projects. Nerves.Runtime does not need to be restricted to the target and allowing on host opens up interactive with the Elixir based firmware code more directly in development (`iex -S mix`) and testing