### PR TITLE
Fix typo in templates/new/config/host.exs

### DIFF
--- a/templates/new/config/host.exs
+++ b/templates/new/config/host.exs
@@ -14,7 +14,7 @@ config :nerves_runtime,
        # https://hexdocs.pm/nerves_runtime/readme.html#nerves-system-and-firmware-metadata
 
        "nerves_fw_active" => "a",
-       "a.nerves_fw_architecture" => "generic"
+       "a.nerves_fw_architecture" => "generic",
        "a.nerves_fw_description" => "N/A",
        "a.nerves_fw_platform" => "host",
        "a.nerves_fw_version" => "0.0.0"


### PR DESCRIPTION
https://github.com/nerves-project/nerves_bootstrap/pull/266

I did [Local development](https://github.com/nerves-project/nerves_bootstrap#local-development).
I found the lack of ',' in templates/new/config/host.exs.

Hope this helps.