### PR TITLE
format @all_targets in templates/new/mix.exs

### DIFF
--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -3,7 +3,9 @@ defmodule <%= app_module %>.MixProject do
 
   @app :<%= app_name %>
   @version "0.1.0"
-  @all_targets <%= inspect(Enum.map(targets, &elem(&1, 0))) %>
+  @all_targets [
+<%= Enum.map(targets, &"    :#{elem(&1, 0)}") |> Enum.join(",\n") %>
+  ]
 
   def project do
     [


### PR DESCRIPTION
I reported https://github.com/nerves-project/nerves_bootstrap/issues/268 .

I use https://github.com/nerves-project/nerves_bootstrap/commit/690a03038d1866d7babea2a85c3ced3c7fb7f49d .
I do [Local development](https://github.com/nerves-project/nerves_bootstrap#local-development).

```
git clone https://github.com/nerves-project/nerves_bootstrap.git
cd nerves_bootstrap
mix do deps.get, archive.build, archive.install

cd ..
mix nerves.new hello_nerves
cd hello_nerves
mix format
```

hello_nerves project changes mix.exs .

This pull request prevents a change of mix.exs in doing `mix format`.

Hope this helps.

