### PR TITLE
Default to global regulatory domain for WiFi

### DIFF
--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -44,9 +44,12 @@ config :nerves_ssh,
   authorized_keys: Enum.map(keys, &File.read!/1)
 
 # Configure the network using vintage_net
+#
+# Update regulatory_domain to your 2-letter country code E.g., "US"
+#
 # See https://github.com/nerves-networking/vintage_net for more information
 config :vintage_net,
-  regulatory_domain: "US",
+  regulatory_domain: "00",
   config: [
     {"usb0", %{type: VintageNetDirect}},
     {"eth0",


### PR DESCRIPTION
The previous option was to default to the US which was an inapproriate
value for a lot of users.

The database can be found at
https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/tree/db.txt.

The affect for US users will be that 5 GHz won't work any more since
it's disabled in `00` (NO-IR = no initiating radiation).
