### PR TITLE
Hard requirement for `:nerves >= 1.8`

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,5 +1,5 @@
 # Run `mix dialyzer --format short` for strings
 [
-  {"lib/nerves_bootstrap.ex:39:unknown_function Function Hex.start/0 does not exist."},
-  {"lib/nerves_bootstrap.ex:40:unknown_function Function Hex.API.Package.get/2 does not exist."}
+  {"lib/nerves_bootstrap.ex:52:unknown_function Function Hex.start/0 does not exist."},
+  {"lib/nerves_bootstrap.ex:53:unknown_function Function Hex.API.Package.get/2 does not exist."}
 ]

--- a/lib/mix/tasks/nerves/bootstrap.ex
+++ b/lib/mix/tasks/nerves/bootstrap.ex
@@ -21,36 +21,26 @@ defmodule Mix.Tasks.Nerves.Bootstrap do
   def run(_args) do
     debug("load nerves START")
 
-    unless Code.ensure_loaded?(Nerves.Env) do
-      _ = Mix.Tasks.Deps.Loadpaths.run(["--no-compile"])
+    nerves_ver = Nerves.Bootstrap.nerves_version()
 
-      # Nerves.Bootstrap used to manage all the Nerves mix tasks and continues
-      # to define them for backwards compatibilty. But the mix tasks were moved
-      # to Nerves in new versions to be maintained there. So if the newer Nerves
-      # version is being used, then there will be lots of warnings about modules
-      # from Nerves.Bootstrap being redefined in Nerves, so we opt to suppress
-      # them only while we compile Nerves, and then set back to original option
-      {ignore?, prev} = get_ignore_opts()
-      Code.put_compiler_option(:ignore_module_conflict, ignore?)
+    if is_nil(nerves_ver) do
+      Mix.raise(":nerves is required as a dependency of this project")
+    end
+
+    if Version.match?(nerves_ver, "< 1.8.0") do
+      Mix.raise(":nerves version requirement not met")
+    end
+
+    unless Code.ensure_loaded?(Nerves.Env) do
+      # The tooling mix tasks are maintained in :nerves so we need to
+      # ensure it is compiled here first so the tasks are available
+      _ = Mix.Tasks.Deps.Loadpaths.run(["--no-compile"])
       Mix.Tasks.Deps.Compile.run(["nerves", "--include-children"])
-      Code.put_compiler_option(:ignore_module_conflict, prev)
     end
 
     Nerves.Bootstrap.check_for_update()
 
     debug("load nerves END")
-  end
-
-  defp get_ignore_opts() do
-    version = Nerves.Bootstrap.nerves_version()
-    prev = Code.get_compiler_option(:ignore_module_conflict) || false
-
-    if version && Version.match?(version, "> 1.7.16") do
-      debug("ignoring module conflict warnings with Nerves")
-      {true, prev}
-    else
-      {false, false}
-    end
   end
 
   defp debug(msg) do

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -6,6 +6,19 @@ defmodule Nerves.Bootstrap do
 
   @impl Application
   def start(_type, _args) do
+    nerves_ver = nerves_version()
+
+    if nerves_ver && Version.match?(nerves_ver, "< 1.8.0") do
+      message = """
+      You are using :nerves #{nerves_ver} which is incompatible with this version
+      of nerves_bootstrap and will result in compilation failures.
+
+      Please update to :nerves >= 1.8.0 or downgrade your nerves_bootstrap <= 1.11.5
+      """
+
+      Mix.shell().info([:yellow, message, :reset])
+    end
+
     Nerves.Bootstrap.Aliases.init()
     {:ok, self()}
   end
@@ -93,13 +106,10 @@ defmodule Nerves.Bootstrap do
           message <>
             """
 
-            It is recommended to update your `:nerves` version also as this update
-            utilizes updates and improvements from `:nerves >= 1.8.0`.
-            (You currently have #{nerves_ver})
+            This version requires `:nerves >= 1.8.0` (You currently have #{nerves_ver})
+            You must also update your `:nerves` dependency by running
 
               mix deps.update nerves
-
-            However, this is backwards compatible if you cannot update `:nerves` at this time.
             """,
         else: message
 

--- a/test/nerves_bootstrap_test.exs
+++ b/test/nerves_bootstrap_test.exs
@@ -139,7 +139,7 @@ defmodule Nerves.BootstrapTest do
     Nerves.Bootstrap.render_update_message(current_version, latest_version, nerves_ver)
 
     assert_receive {:mix_shell, :info, [message]}
-    assert message =~ "It is recommended to update your `:nerves`"
+    assert message =~ "This version requires `:nerves >= 1.8.0`"
   end
 
   test "Does not include nerves message when acceptable version in deps" do
@@ -149,6 +149,6 @@ defmodule Nerves.BootstrapTest do
     Nerves.Bootstrap.render_update_message(current_version, latest_version, nerves_ver)
 
     assert_receive {:mix_shell, :info, [message]}
-    refute message =~ "It is recommended to update your `:nerves`"
+    refute message =~ "This version requires `:nerves >= 1.8.0`"
   end
 end


### PR DESCRIPTION
The mix tooling was moved to Nerves starting in 1.8. Since we removed the duplicated tasks from the attic code, we now need to require this version of Nerves for future versions of Nerves bootstrap.

This adds compilation failures and warnings where possible to help people through the transition

---

<img width="806" alt="Screenshot 2023-09-27 at 5 59 30 PM" src="https://github.com/nerves-project/nerves_bootstrap/assets/11321326/c7485be6-f5ec-4cc9-8aa3-dc7b08ec69ad">

<img width="689" alt="Screenshot 2023-09-27 at 6 01 42 PM" src="https://github.com/nerves-project/nerves_bootstrap/assets/11321326/5b399b8b-1533-4603-ba3c-d391ac8ce205">

<img width="525" alt="Screenshot 2023-09-27 at 6 03 43 PM" src="https://github.com/nerves-project/nerves_bootstrap/assets/11321326/eeb72528-1910-40d6-8814-30d0a9a93fa7">
