### PR TITLE
Move Nerves version check to deps.precompile

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,5 +1,5 @@
 # Run `mix dialyzer --format short` for strings
 [
-  {"lib/nerves_bootstrap.ex:52:unknown_function Function Hex.start/0 does not exist."},
-  {"lib/nerves_bootstrap.ex:53:unknown_function Function Hex.API.Package.get/2 does not exist."}
+  {"lib/nerves_bootstrap.ex:41:unknown_function Function Hex.start/0 does not exist."},
+  {"lib/nerves_bootstrap.ex:42:unknown_function Function Hex.API.Package.get/2 does not exist."}
 ]

--- a/lib/mix/tasks/nerves/bootstrap.ex
+++ b/lib/mix/tasks/nerves/bootstrap.ex
@@ -28,12 +28,19 @@ defmodule Mix.Tasks.Nerves.Bootstrap do
     end
 
     if Version.match?(nerves_ver, "< 1.8.0") do
-      Mix.raise(":nerves version requirement not met")
+      Mix.raise("""
+      You are using :nerves #{nerves_ver} which is incompatible with this version
+      of nerves_bootstrap and will result in compilation failures.
+
+      Please update to :nerves >= 1.8.0 or downgrade your nerves_bootstrap <= 1.11.5
+      """)
     end
 
-    unless Code.ensure_loaded?(Nerves.Env) do
+    if Mix.target() != :host and not Code.ensure_loaded?(Nerves.Env) do
       # The tooling mix tasks are maintained in :nerves so we need to
-      # ensure it is compiled here first so the tasks are available
+      # ensure it is compiled here first so the tasks are available.
+      # If the target is host, then this will be handled by the regular
+      # compilation process
       _ = Mix.Tasks.Deps.Loadpaths.run(["--no-compile"])
       Mix.Tasks.Deps.Compile.run(["nerves", "--include-children"])
     end

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -6,19 +6,6 @@ defmodule Nerves.Bootstrap do
 
   @impl Application
   def start(_type, _args) do
-    nerves_ver = nerves_version()
-
-    if nerves_ver && Version.match?(nerves_ver, "< 1.8.0") do
-      message = """
-      You are using :nerves #{nerves_ver} which is incompatible with this version
-      of nerves_bootstrap and will result in compilation failures.
-
-      Please update to :nerves >= 1.8.0 or downgrade your nerves_bootstrap <= 1.11.5
-      """
-
-      Mix.shell().info([:yellow, message, :reset])
-    end
-
     Nerves.Bootstrap.Aliases.init()
     {:ok, self()}
   end
@@ -37,6 +24,8 @@ defmodule Nerves.Bootstrap do
     if path = Mix.Project.deps_paths()[:nerves] do
       Mix.Project.in_project(:nerves, path, fn _ -> Mix.Project.config()[:version] end)
     end
+  catch
+    _, _ -> nil
   end
 
   @doc """

--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -41,6 +41,7 @@ defmodule Nerves.Bootstrap.Aliases do
     aliases
     |> append("deps.get", "nerves.bootstrap")
     |> append("deps.get", "nerves.deps.get")
+    |> prepend("deps.precompile", "nerves.bootstrap")
     |> replace("deps.update", &Nerves.Bootstrap.Aliases.deps_update/1)
   end
 

--- a/test/nerves_bootstrap_test.exs
+++ b/test/nerves_bootstrap_test.exs
@@ -5,12 +5,14 @@ defmodule Nerves.BootstrapTest do
     deps_loadpaths = ["nerves.bootstrap", "nerves.loadpaths", "deps.loadpaths"]
     deps_get = ["deps.get", "nerves.bootstrap", "nerves.deps.get"]
     deps_update = [&Nerves.Bootstrap.Aliases.deps_update/1]
+    deps_precompile = ["nerves.bootstrap", "deps.precompile"]
     deps_compile = ["nerves.bootstrap", "nerves.loadpaths", "deps.compile"]
 
     aliases = Nerves.Bootstrap.add_aliases([])
     assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
     assert Keyword.get(aliases, :"deps.get") == deps_get
     assert Keyword.get(aliases, :"deps.update") == deps_update
+    assert Keyword.get(aliases, :"deps.precompile") == deps_precompile
     assert Keyword.get(aliases, :"deps.compile") == deps_compile
   end
 


### PR DESCRIPTION
If a user does not have a `deps` folder with Nerves fetched, then the new Nerves version check would error out as Nerves.Bootstrap is starting. However, the compilation would continue and other libs later on would fail to compile because they would be missing the Nerves tooling as a result of the bootstraping crash.

To fix this, the check has been moved to the `nerves.bootstrap` task and also added before `deps.precompile` to ensure the deps are fetched first before attempting to read any of the `:nerves` dep information