### PR TITLE
Remove autogenerated target function

### DIFF
--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -8,8 +8,6 @@ import Config
 # Enable the Nerves integration with Mix
 Application.start(:nerves_bootstrap)
 
-config :<%= app_name %>, target: Mix.target()
-
 # Customize non-Elixir parts of the firmware. See
 # https://hexdocs.pm/nerves/advanced-configuration.html for details.
 

--- a/templates/new/lib/app_name/application.ex
+++ b/templates/new/lib/app_name/application.ex
@@ -36,8 +36,4 @@ defmodule <%= app_module %>.Application do
       # {<%= app_module %>.Worker, arg},
     ]
   end
-
-  def target() do
-    Application.get_env(:<%= app_name %>, :target)
-  end
 end


### PR DESCRIPTION
This has been replaced by `Nerves.Runtime.mix_target/0`.
