### PR TITLE
Require the Elixir version that runs mix nerves.new

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,7 @@ tags: &tags
     1.16.3-erlang-26.2.5-alpine-3.20.0,
     1.15.7-erlang-26.1.2-alpine-3.18.4,
     1.14.5-erlang-25.3.2-alpine-3.18.0,
-    1.13.4-erlang-24.3.4.11-alpine-3.18.0,
-    1.12.3-erlang-24.3.4.11-alpine-3.18.0,
-    1.11.4-erlang-23.3.4.18-alpine-3.16.2
+    1.13.4-erlang-24.3.4.11-alpine-3.18.0
   ]
 
 jobs:

--- a/lib/mix/tasks/nerves/new.ex
+++ b/lib/mix/tasks/nerves/new.ex
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Nerves.New do
   @nerves_pack_vsn "0.7.1"
   @toolshed_vsn "0.4.0"
 
-  @elixir_vsn "~> 1.11"
+  @elixir_requirement "~> 1.13"
 
   @targets [
     {:rpi, "1.24"},
@@ -124,9 +124,9 @@ defmodule Mix.Tasks.Nerves.New do
   end
 
   def run(argv) do
-    unless Version.match?(System.version(), @elixir_vsn) do
+    unless Version.match?(System.version(), @elixir_requirement) do
       Mix.raise("""
-      Nerves Bootstrap v#{@bootstrap_vsn} creates projects that require Elixir #{@elixir_vsn}.
+      Nerves Bootstrap v#{@bootstrap_vsn} creates projects that require Elixir #{@elixir_requirement}.
 
       You have Elixir #{System.version()}. Please update your Elixir version or downgrade
       the version of Nerves Bootstrap that you're using.
@@ -197,6 +197,7 @@ defmodule Mix.Tasks.Nerves.New do
     targets = if targets == [], do: @targets, else: targets
     cookie = opts[:cookie]
     source_date_epoch = Keyword.get(opts, :source_date_epoch, generate_source_date_epoch())
+    elixir_version = System.version() |> Version.parse!()
 
     binding = [
       app_name: app,
@@ -205,7 +206,7 @@ defmodule Mix.Tasks.Nerves.New do
       shoehorn_vsn: @shoehorn_vsn,
       runtime_vsn: @runtime_vsn,
       ring_logger_vsn: @ring_logger_vsn,
-      elixir_req: @elixir_vsn,
+      elixir_req: "~> #{elixir_version.major}.#{elixir_version.minor}",
       nerves_dep: nerves_dep(nerves_path),
       in_umbrella: in_umbrella?,
       nerves_pack?: nerves_pack?,

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Nerves.Bootstrap.MixProject do
     [
       app: :nerves_bootstrap,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.13",
       aliases: aliases(),
       xref: [exclude: [Nerves.Env, Hex, Hex.API.Package, EEx]],
       docs: docs(),


### PR DESCRIPTION
Since the generated project has a dependency on the Elixir version due
to the vm.args.eex file, set the required Elixir version in the
generated mix.exs. This should hopefully alert a user that something is
amiss if they generate a Nerves project with Elixir 1.17 and go back to
1.16. That way the runtime error due to how IEx is started in the
vm.args.eex will hopefully be less surprising. I.e., we warned you with
the Elixir version warning that something might break. Unfortunately,
this doesn't go the other way with upgrading Elixir versions.
