### PR TITLE
Use `Nerves.Runtime.mix_target()` for child selection

### DIFF
--- a/templates/new/lib/app_name/application.ex
+++ b/templates/new/lib/app_name/application.ex
@@ -12,7 +12,7 @@ defmodule <%= app_module %>.Application do
         # Children for all targets
         # Starts a worker by calling: <%= app_module %>.Worker.start_link(arg)
         # {<%= app_module %>.Worker, arg},
-      ] ++ children(target())
+      ] ++ children(Nerves.Runtime.mix_target())
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options


### PR DESCRIPTION
The previous `target()` function generated was removed in c70df685 and this updates the generated `application.ex` to use the expected `Nerves.Runtime.mix_target/0` for selectively choosing children to start in the supervisor