### PR TITLE
Add :logger config for host.exs

### DIFF
--- a/templates/new/config/host.exs
+++ b/templates/new/config/host.exs
@@ -2,6 +2,8 @@ import Config
 
 # Add configuration that is only needed when running on the host here.
 
+config :logger, backends: [:console]
+
 config :nerves_runtime,
   kv_backend:
     {Nerves.Runtime.KVBackend.InMemory,


### PR DESCRIPTION
I think :logger config `:console` is better to be included in the host.exs for the host machine development.