### PR TITLE
Remove remaining workarounds for before Mix.target

### DIFF
--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -105,16 +105,6 @@ defmodule Nerves.Bootstrap do
     Mix.shell().info([:yellow, message, :reset])
   end
 
-  @spec mix_target() :: atom()
-  def mix_target() do
-    if function_exported?(Mix, :target, 0) do
-      apply(Mix, :target, [])
-    else
-      (System.get_env("MIX_TARGET") || "host")
-      |> String.to_atom()
-    end
-  end
-
   defp filter_pre_release(releases, %{pre: []}) do
     releases
     |> Enum.filter(&(Map.get(&1, :pre) == []))

--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -9,7 +9,7 @@ defmodule Nerves.Bootstrap.Aliases do
       adjusted_config =
         config
         |> update_host_config()
-        |> update_target_config(Nerves.Bootstrap.mix_target())
+        |> update_target_config(Mix.target())
 
       :ok = Mix.ProjectStack.push(name, adjusted_config, file)
     else
@@ -57,17 +57,17 @@ defmodule Nerves.Bootstrap.Aliases do
 
   @spec run([String.t()]) :: :ok
   def run(args) do
-    case Nerves.Bootstrap.mix_target() do
-      :host ->
-        Mix.Tasks.Run.run(args)
+    target = Mix.target()
 
-      target ->
-        msg = """
-        You are trying to run code compiled for #{target}
-        on your host. Please unset MIX_TARGET to run in host mode.
-        """
+    if target == :host do
+      Mix.Tasks.Run.run(args)
+    else
+      msg = """
+      You are trying to run code compiled for #{target}
+      on your host. Please unset MIX_TARGET to run in host mode.
+      """
 
-        Mix.shell().error([:inverse, :red, "|nerves_bootstrap| ", msg, :reset])
+      Mix.shell().error([:inverse, :red, "|nerves_bootstrap| ", msg, :reset])
     end
   end
 


### PR DESCRIPTION
It's hard to believe there was a time when the Mix.target function
didn't exist it's been so long.
