### PR TITLE
Add Nerves.Bootstrap.version/0 back to fix nerves.info

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,8 @@
 # SPDX-FileCopyrightText: None
 # SPDX-License-Identifier: CC0-1.0
 [
-  inputs: ["{mix,.formatter,.credo,.dialyzer_ignore}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: [
+    "{mix,.formatter,.credo,.dialyzer_ignore}.exs",
+    "{compat,config,lib,test}/**/*.{ex,exs}"
+  ]
 ]

--- a/compat/nerves.bootstrap.ex
+++ b/compat/nerves.bootstrap.ex
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Frank Hunleth
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Nerves.Bootstrap do
+  @moduledoc false
+
+  # Do not use!
+  # This is kept for compatibility with Nerves v1.4 and earlier. It was called
+  # by `mix nerves.info`.
+  @spec version() :: String.t()
+  def version(), do: unquote(Mix.Project.config()[:version])
+end

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule NervesBootstrap.MixProject do
       app: :nerves_bootstrap,
       version: @version,
       elixir: "~> 1.15",
+      elixirc_paths: ["lib", "compat"],
       aliases: aliases(),
       xref: [exclude: [Nerves.Env, Hex, Hex.API.Package, EEx]],
       docs: docs(),
@@ -74,6 +75,7 @@ defmodule NervesBootstrap.MixProject do
     [
       files: [
         "CHANGELOG.md",
+        "compat",
         "lib",
         "LICENSES/*",
         "mix.exs",

--- a/test/compat/nerves.bootstrap_test.exs
+++ b/test/compat/nerves.bootstrap_test.exs
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025 Frank Hunleth
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Nerves.BootstrapTest do
+  use ExUnit.Case
+
+  test "returns Nerves Bootstrap version" do
+    vsn = Nerves.Bootstrap.version()
+    expected = Application.spec(:nerves_bootstrap, :vsn) |> to_string()
+
+    assert vsn == expected
+  end
+end


### PR DESCRIPTION
See
https://github.com/nerves-project/nerves/commit/94a0db2572dd054c2e386660f3a8764724277bd7
for the update to Nerves that removes the call to
`Nerves.Bootstrap.version/0`.
