### PR TITLE
Update HexDoc URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,7 +257,7 @@ Elixir 1.13 as the minimum supported version
 ## 1.9.0
 
 * New project generator updates
-  * Bump [NervesPack to 0.4](https://hexdocs.pm/nerves_pack/changelog.html#v0-4-0)
+  * Bump [NervesPack to 0.4](https://nerves-pack.hexdocs.pm/changelog.html#v0-4-0)
     which drops `:nerves_firmware_ssh` in favor of `:nerves_ssh` and
     `:ssh_subsystem_fwup` for access and updates.
   * Bump Nerves to `~> 1.6.3`
@@ -383,7 +383,7 @@ dependencies for a device. This lets you switch between building for different
 boards and your host. Elixir 1.8 pulls this support into `mix` and lets you
 annotate dependencies for which targets they should be used.
 
-See the [project update guide](https://hexdocs.pm/nerves/updating-projects.html#updating-from-v1-3-x-to-v1-4-x) to learn how to migrate your project.
+See the [project update guide](https://nerves.hexdocs.pm/updating-projects.html#updating-from-v1-3-x-to-v1-4-x) to learn how to migrate your project.
 
 * Enhancements
   * New projects are generated for Elixir 1.8.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 # NervesBootstrap
 
 [![Hex version](https://img.shields.io/hexpm/v/nerves_bootstrap.svg "Hex version")](https://hex.pm/packages/nerves_bootstrap)
-[![API docs](https://img.shields.io/hexpm/v/nerves_bootstrap.svg?label=hexdocs "API docs")](https://hexdocs.pm/nerves_bootstrap/index.html)
+[![API docs](https://img.shields.io/hexpm/v/nerves_bootstrap.svg?label=hexdocs "API docs")](https://nerves-bootstrap.hexdocs.pm/index.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-project/nerves_bootstrap/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-project/nerves_bootstrap/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/nerves_bootstrap)](https://api.reuse.software/info/github.com/nerves-project/nerves_bootstrap)
 
@@ -17,7 +17,7 @@ NervesBootstrap is an Elixir archive that brings Nerves support to Elixir's Mix
 build tool and provides a new project generator, `mix nerves.new`.
 
 We recommend reading the [Nerves Installation
-Guide](https://hexdocs.pm/nerves/installation.html) for installing and using
+Guide](https://nerves.hexdocs.pm/installation.html) for installing and using
 Nerves. Read on for details specific to NervesBootstrap.
 
 ## Installation

--- a/lib/mix/tasks/nerves.new.ex
+++ b/lib/mix/tasks/nerves.new.ex
@@ -26,7 +26,7 @@ defmodule Mix.Tasks.Nerves.New do
 
   A `--target` option can be given to limit support to one or more of the
   [officially Nerves
-  systems](https://hexdocs.pm/nerves/supported-targets.html).
+  systems](https://nerves.hexdocs.pm/supported-targets.html).
 
   A `--cookie` options can be given to set the Erlang distribution
   cookie in `vm.args`. This defaults to a randomly generated string.
@@ -140,7 +140,7 @@ defmodule Mix.Tasks.Nerves.New do
       You have Elixir #{System.version()}. Please update your Elixir version or downgrade
       the version of Nerves Bootstrap that you're using.
 
-      See https://hexdocs.pm/nerves/installation.html for more information on
+      See https://nerves.hexdocs.pm/installation.html for more information on
       setting up your environment.
       """)
     end
@@ -242,7 +242,7 @@ defmodule Mix.Tasks.Nerves.New do
     Mix.shell().info("""
     Your Nerves project was created successfully.
 
-    You should now pick a target. See https://hexdocs.pm/nerves/supported-targets.html
+    You should now pick a target. See https://nerves.hexdocs.pm/supported-targets.html
     for supported target tags. If your target is on the list, set `MIX_TARGET`
     to its tag name:
 

--- a/templates/new/README.md
+++ b/templates/new/README.md
@@ -12,7 +12,7 @@ a short name like `rpi3` that maps to a Nerves system image for that platform.
 All of this logic is in the generated `mix.exs` and may be customized. For more
 information about targets see:
 
-https://hexdocs.pm/nerves/supported-targets.html
+https://nerves.hexdocs.pm/supported-targets.html
 
 ## Getting Started
 
@@ -25,7 +25,7 @@ To start your Nerves app:
 
 ## Learn more
 
-  * Official docs: https://hexdocs.pm/nerves/getting-started.html
+  * Official docs: https://nerves.hexdocs.pm/getting-started.html
   * Official website: https://nerves-project.org/
   * Forum: https://elixirforum.com/c/nerves-forum
   * Elixir Slack #nerves channel: https://elixir-slack.community/

--- a/templates/new/config/config.exs
+++ b/templates/new/config/config.exs
@@ -9,7 +9,7 @@ import Config
 Application.start(:nerves_bootstrap)
 
 # Customize non-Elixir parts of the firmware. See
-# https://hexdocs.pm/nerves/advanced-configuration.html for details.
+# https://nerves.hexdocs.pm/advanced-configuration.html for details.
 
 config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 

--- a/templates/new/config/host.exs
+++ b/templates/new/config/host.exs
@@ -10,8 +10,8 @@ config :nerves_runtime,
        # this allows us to use a pre-populated InMemory store when running on
        # host for development and testing.
        #
-       # https://hexdocs.pm/nerves_runtime/readme.html#using-nerves_runtime-in-tests
-       # https://hexdocs.pm/nerves_runtime/readme.html#nerves-system-and-firmware-metadata
+       # https://nerves-runtime.hexdocs.pm/readme.html#using-nerves_runtime-in-tests
+       # https://nerves-runtime.hexdocs.pm/readme.html#nerves-system-and-firmware-metadata
 
        "nerves_fw_active" => "a",
        "a.nerves_fw_architecture" => "generic",

--- a/templates/new/config/target.exs
+++ b/templates/new/config/target.exs
@@ -1,7 +1,7 @@
 import Config
 
 # Use Ringlogger as the logger backend and remove :console.
-# See https://hexdocs.pm/ring_logger/readme.html for more information on
+# See https://ring-logger.hexdocs.pm/readme.html for more information on
 # configuring ring_logger.
 
 config :logger, backends: [RingLogger]
@@ -28,8 +28,8 @@ config :nerves, :erlinit, update_clock: true
 
 # Configure the device for SSH IEx prompt access and firmware updates
 #
-# * See https://hexdocs.pm/nerves_ssh/readme.html for general SSH configuration
-# * See https://hexdocs.pm/ssh_subsystem_fwup/readme.html for firmware updates
+# * See https://nerves-ssh.hexdocs.pm/readme.html for general SSH configuration
+# * See https://ssh-subsystem-fwup.hexdocs.pm/readme.html for firmware updates
 
 keys =
   System.user_home!()

--- a/templates/new/lib/app_name/application.ex
+++ b/templates/new/lib/app_name/application.ex
@@ -1,5 +1,5 @@
 defmodule <%= app_module %>.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -14,7 +14,7 @@ defmodule <%= app_module %>.Application do
         # {<%= app_module %>.Worker, arg},
       ] ++ target_children()
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: <%= app_module %>.Supervisor]
     Supervisor.start_link(children, opts)

--- a/templates/new/mix.exs
+++ b/templates/new/mix.exs
@@ -63,7 +63,7 @@ defmodule <%= app_module %>.MixProject do
     [
       overwrite: true,
 <%= if nerves_pack? do %>      # Erlang distribution is not started automatically.
-      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
+      # See https://nerves-pack.hexdocs.pm/readme.html#erlang-distribution
 <% end %>      cookie: <%= if cookie do %>"<%= cookie %>"<% else %>"#{@app}_cookie"<% end %>,
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],

--- a/test_fixtures/nerves_1x_otp26/config/config.exs
+++ b/test_fixtures/nerves_1x_otp26/config/config.exs
@@ -9,7 +9,7 @@ import Config
 Application.start(:nerves_bootstrap)
 
 # Customize non-Elixir parts of the firmware. See
-# https://hexdocs.pm/nerves/advanced-configuration.html for details.
+# https://nerves.hexdocs.pm/advanced-configuration.html for details.
 
 config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 

--- a/test_fixtures/nerves_1x_otp26/config/host.exs
+++ b/test_fixtures/nerves_1x_otp26/config/host.exs
@@ -10,8 +10,8 @@ config :nerves_runtime,
        # this allows us to use a pre-populated InMemory store when running on
        # host for development and testing.
        #
-       # https://hexdocs.pm/nerves_runtime/readme.html#using-nerves_runtime-in-tests
-       # https://hexdocs.pm/nerves_runtime/readme.html#nerves-system-and-firmware-metadata
+       # https://nerves-runtime.hexdocs.pm/readme.html#using-nerves_runtime-in-tests
+       # https://nerves-runtime.hexdocs.pm/readme.html#nerves-system-and-firmware-metadata
 
        "nerves_fw_active" => "a",
        "a.nerves_fw_architecture" => "generic",

--- a/test_fixtures/nerves_1x_otp26/config/target.exs
+++ b/test_fixtures/nerves_1x_otp26/config/target.exs
@@ -1,7 +1,7 @@
 import Config
 
 # Use Ringlogger as the logger backend and remove :console.
-# See https://hexdocs.pm/ring_logger/readme.html for more information on
+# See https://ring-logger.hexdocs.pm/readme.html for more information on
 # configuring ring_logger.
 
 config :logger, backends: [RingLogger]
@@ -28,8 +28,8 @@ config :nerves, :erlinit, update_clock: true
 
 # Configure the device for SSH IEx prompt access and firmware updates
 #
-# * See https://hexdocs.pm/nerves_ssh/readme.html for general SSH configuration
-# * See https://hexdocs.pm/ssh_subsystem_fwup/readme.html for firmware updates
+# * See https://nerves-ssh.hexdocs.pm/readme.html for general SSH configuration
+# * See https://ssh-subsystem-fwup.hexdocs.pm/readme.html for firmware updates
 
 keys =
   System.user_home!()

--- a/test_fixtures/nerves_1x_otp26/lib/nerves_1x_otp26/application.ex
+++ b/test_fixtures/nerves_1x_otp26/lib/nerves_1x_otp26/application.ex
@@ -1,5 +1,5 @@
 defmodule Nerves1xOtp26.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -14,7 +14,7 @@ defmodule Nerves1xOtp26.Application do
         # {Nerves1xOtp26.Worker, arg},
       ] ++ target_children()
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Nerves1xOtp26.Supervisor]
     Supervisor.start_link(children, opts)

--- a/test_fixtures/nerves_1x_otp27/config/config.exs
+++ b/test_fixtures/nerves_1x_otp27/config/config.exs
@@ -9,7 +9,7 @@ import Config
 Application.start(:nerves_bootstrap)
 
 # Customize non-Elixir parts of the firmware. See
-# https://hexdocs.pm/nerves/advanced-configuration.html for details.
+# https://nerves.hexdocs.pm/advanced-configuration.html for details.
 
 config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 

--- a/test_fixtures/nerves_1x_otp27/config/host.exs
+++ b/test_fixtures/nerves_1x_otp27/config/host.exs
@@ -10,8 +10,8 @@ config :nerves_runtime,
        # this allows us to use a pre-populated InMemory store when running on
        # host for development and testing.
        #
-       # https://hexdocs.pm/nerves_runtime/readme.html#using-nerves_runtime-in-tests
-       # https://hexdocs.pm/nerves_runtime/readme.html#nerves-system-and-firmware-metadata
+       # https://nerves-runtime.hexdocs.pm/readme.html#using-nerves_runtime-in-tests
+       # https://nerves-runtime.hexdocs.pm/readme.html#nerves-system-and-firmware-metadata
 
        "nerves_fw_active" => "a",
        "a.nerves_fw_architecture" => "generic",

--- a/test_fixtures/nerves_1x_otp27/config/target.exs
+++ b/test_fixtures/nerves_1x_otp27/config/target.exs
@@ -1,7 +1,7 @@
 import Config
 
 # Use Ringlogger as the logger backend and remove :console.
-# See https://hexdocs.pm/ring_logger/readme.html for more information on
+# See https://ring-logger.hexdocs.pm/readme.html for more information on
 # configuring ring_logger.
 
 config :logger, backends: [RingLogger]
@@ -28,8 +28,8 @@ config :nerves, :erlinit, update_clock: true
 
 # Configure the device for SSH IEx prompt access and firmware updates
 #
-# * See https://hexdocs.pm/nerves_ssh/readme.html for general SSH configuration
-# * See https://hexdocs.pm/ssh_subsystem_fwup/readme.html for firmware updates
+# * See https://nerves-ssh.hexdocs.pm/readme.html for general SSH configuration
+# * See https://ssh-subsystem-fwup.hexdocs.pm/readme.html for firmware updates
 
 keys =
   System.user_home!()

--- a/test_fixtures/nerves_1x_otp27/lib/nerves_1x_otp27/application.ex
+++ b/test_fixtures/nerves_1x_otp27/lib/nerves_1x_otp27/application.ex
@@ -1,5 +1,5 @@
 defmodule Nerves1xOtp27.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -14,7 +14,7 @@ defmodule Nerves1xOtp27.Application do
         # {Nerves1xOtp27.Worker, arg},
       ] ++ target_children()
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Nerves1xOtp27.Supervisor]
     Supervisor.start_link(children, opts)

--- a/test_fixtures/nerves_1x_otp27/mix.exs
+++ b/test_fixtures/nerves_1x_otp27/mix.exs
@@ -52,7 +52,7 @@ defmodule Nerves1xOtp27.MixProject do
     [
       overwrite: true,
       # Erlang distribution is not started automatically.
-      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
+      # See https://nerves-pack.hexdocs.pm/readme.html#erlang-distribution
       cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],

--- a/test_fixtures/nerves_1x_otp28/config/config.exs
+++ b/test_fixtures/nerves_1x_otp28/config/config.exs
@@ -9,7 +9,7 @@ import Config
 Application.start(:nerves_bootstrap)
 
 # Customize non-Elixir parts of the firmware. See
-# https://hexdocs.pm/nerves/advanced-configuration.html for details.
+# https://nerves.hexdocs.pm/advanced-configuration.html for details.
 
 config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 

--- a/test_fixtures/nerves_1x_otp28/config/host.exs
+++ b/test_fixtures/nerves_1x_otp28/config/host.exs
@@ -10,8 +10,8 @@ config :nerves_runtime,
        # this allows us to use a pre-populated InMemory store when running on
        # host for development and testing.
        #
-       # https://hexdocs.pm/nerves_runtime/readme.html#using-nerves_runtime-in-tests
-       # https://hexdocs.pm/nerves_runtime/readme.html#nerves-system-and-firmware-metadata
+       # https://nerves-runtime.hexdocs.pm/readme.html#using-nerves_runtime-in-tests
+       # https://nerves-runtime.hexdocs.pm/readme.html#nerves-system-and-firmware-metadata
 
        "nerves_fw_active" => "a",
        "a.nerves_fw_architecture" => "generic",

--- a/test_fixtures/nerves_1x_otp28/config/target.exs
+++ b/test_fixtures/nerves_1x_otp28/config/target.exs
@@ -1,7 +1,7 @@
 import Config
 
 # Use Ringlogger as the logger backend and remove :console.
-# See https://hexdocs.pm/ring_logger/readme.html for more information on
+# See https://ring-logger.hexdocs.pm/readme.html for more information on
 # configuring ring_logger.
 
 config :logger, backends: [RingLogger]
@@ -28,8 +28,8 @@ config :nerves, :erlinit, update_clock: true
 
 # Configure the device for SSH IEx prompt access and firmware updates
 #
-# * See https://hexdocs.pm/nerves_ssh/readme.html for general SSH configuration
-# * See https://hexdocs.pm/ssh_subsystem_fwup/readme.html for firmware updates
+# * See https://nerves-ssh.hexdocs.pm/readme.html for general SSH configuration
+# * See https://ssh-subsystem-fwup.hexdocs.pm/readme.html for firmware updates
 
 keys =
   System.user_home!()

--- a/test_fixtures/nerves_1x_otp28/lib/nerves_1x_otp28/application.ex
+++ b/test_fixtures/nerves_1x_otp28/lib/nerves_1x_otp28/application.ex
@@ -1,5 +1,5 @@
 defmodule Nerves1xOtp28.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -14,7 +14,7 @@ defmodule Nerves1xOtp28.Application do
         # {Nerves1xOtp28.Worker, arg},
       ] ++ target_children()
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Nerves1xOtp28.Supervisor]
     Supervisor.start_link(children, opts)

--- a/test_fixtures/nerves_1x_otp28/mix.exs
+++ b/test_fixtures/nerves_1x_otp28/mix.exs
@@ -53,7 +53,7 @@ defmodule Nerves1xOtp28.MixProject do
     [
       overwrite: true,
       # Erlang distribution is not started automatically.
-      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
+      # See https://nerves-pack.hexdocs.pm/readme.html#erlang-distribution
       cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves-bootstrap.hexdocs.pm/index.html): Status 404
❌ Verification failed for https://nerves.hexdocs.pm/installation.html): Status 301
❌ Verification failed for https://nerves.hexdocs.pm/supported-targets.html): Status 301
⚠️ Verification finished: 14 success, 3 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>