### PR TITLE
Temporarily drop OSD32MP1 and GRiSP2 from autogenerator

### DIFF
--- a/lib/mix/tasks/nerves.new.ex
+++ b/lib/mix/tasks/nerves.new.ex
@@ -75,8 +75,6 @@ defmodule Mix.Tasks.Nerves.New do
 
   @targets [
     {:bbb, "2.19"},
-    {:grisp2, "0.8"},
-    {:osd32mp1, "0.15"},
     {:mangopi_mq_pro, "0.6"},
     {:qemu_aarch64, "0.1"},
     {:rpi, "2.0"},

--- a/test/mix/tasks/nerves.new_test.exs
+++ b/test/mix/tasks/nerves.new_test.exs
@@ -38,12 +38,7 @@ defmodule Mix.Tasks.Nerves.NewTest do
         assert file =~ "{:nerves_system_rpi4, \"~> 2.0\", runtime: false, targets: :rpi4"
         assert file =~ "{:nerves_system_rpi5, \"~> 2.0\", runtime: false, targets: :rpi5"
         assert file =~ "{:nerves_system_bbb, \"~> 2.19\", runtime: false, targets: :bbb"
-
-        assert file =~
-                 "{:nerves_system_osd32mp1, \"~> 0.15\", runtime: false, targets: :osd32mp1"
-
         assert file =~ "{:nerves_system_x86_64, \"~> 1.24\", runtime: false, targets: :x86_64"
-        assert file =~ "{:nerves_system_grisp2, \"~> 0.8\", runtime: false, targets: :grisp2"
 
         assert file =~
                  "{:nerves_system_mangopi_mq_pro, \"~> 0.6\", runtime: false, targets: :mangopi_mq_pro"


### PR DESCRIPTION
Both of these need Linux kernel version updates to support the new
toolchains. They can still be used, but will cause dependency resolution
issues if included in the same mix.exs file as systems using GCC 15.3.
