### PR TITLE
Alter the way aliases are injected when using Nerves 2

### DIFF
--- a/lib/mix/tasks/nerves.bootstrap.ex
+++ b/lib/mix/tasks/nerves.bootstrap.ex
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 defmodule Mix.Tasks.Nerves.Bootstrap do
-  # Bootstrap Nerves tooling into the current Mix tooling
+  # Nerves v1 initialization
   #
   # The purpose of this task is to ensure the Nerves integration is compiled
   # first and available to be injected into the Mix tooling since NervesBootstrap

--- a/lib/mix/tasks/nerves.bootstrap.ex
+++ b/lib/mix/tasks/nerves.bootstrap.ex
@@ -17,45 +17,8 @@ defmodule Mix.Tasks.Nerves.Bootstrap do
   @moduledoc false
   use Mix.Task
 
-  alias NervesBootstrap.UpdateChecker
-
   @impl Mix.Task
   def run(_args) do
-    UpdateChecker.check()
-
-    nerves_ver = nerves_version()
-
-    if is_nil(nerves_ver) do
-      Mix.raise("""
-      Your project is using Nerves bootstrap but doesn't depend on Nerves.
-
-      Please check the dependency section of your mix.exs.
-      """)
-    end
-
-    # Check that the Nerves version is new enough to support this
-    # version of Nerves Bootstrap.
-    #
-    # This version of Nerves Bootstrap fails to install when the
-    # Elixir version is less than 1.15, so we're guaranteed that
-    # version. That forces a constraint on what Nerves versions
-    # can be used. Here's a truncated list for convenience.
-    #
-    # | Nerves version | Min Elixir version          | Max Elixir |
-    # |----------------|-----------------------------|------------|
-    # | 1.11.3         | 1.13                        | 1.18       |
-    # | 1.12.0         | 1.15.1                      | 1.19.      |
-    # | 1.14.3         | 1.15.1 (inherited)          | 1.20.      |
-
-    if Version.match?(nerves_ver, "< 1.11.3") do
-      Mix.raise("""
-      You are using :nerves #{nerves_ver} which is incompatible with this version
-      of nerves_bootstrap and will result in compilation failures.
-
-      Please update to :nerves >= 1.11.3.
-      """)
-    end
-
     if Mix.target() != :host and not Code.ensure_loaded?(Nerves.Env) do
       # The tooling mix tasks are maintained in :nerves so we need to
       # ensure it is compiled here first so the tasks are available.
@@ -68,13 +31,5 @@ defmodule Mix.Tasks.Nerves.Bootstrap do
     # Do not call Nerves Bootstrap code from other modules here. The modules
     # aren't available in Elixir 1.18 and earlier if `:nerves` doesn't pull
     # them in.
-  end
-
-  defp nerves_version() do
-    if path = Mix.Project.deps_paths()[:nerves] do
-      Mix.Project.in_project(:nerves, path, fn _ -> Mix.Project.config()[:version] end)
-    end
-  catch
-    _, _ -> nil
   end
 end

--- a/lib/mix/tasks/nerves_bootstrap.init.ex
+++ b/lib/mix/tasks/nerves_bootstrap.init.ex
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Frank Hunleth
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Mix.Tasks.NervesBootstrap.Init do
+  # Nerves v2 initialization
+  #
+  # This mix task ensures that the nerves.init task is run first
+  # so that it can configure the compilation environment for
+  # building other packages. This is important since it affects
+  # how NIFs and ports get compiled.
+  @moduledoc false
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_args) do
+    # Check if Nerves has already been compiled and we can chain directly to it
+    minimal_loadpaths()
+
+    if not Code.ensure_loaded?(Nerves) do
+      # Compile Nerves and its dependencies
+      Mix.Tasks.Deps.Compile.run(["--include-children", "nerves"])
+
+      # Make Nerves available in the load path
+      minimal_loadpaths()
+    end
+
+    # Do not call Nerves Bootstrap code from other modules here. The modules
+    # aren't available in Elixir 1.18 and earlier if `:nerves` doesn't pull
+    # them in.
+
+    # Chain to the Nerves tooling
+    Mix.Task.run("nerves.init", [])
+  end
+
+  defp minimal_loadpaths() do
+    # Load only what's available. Really, only "--no-deps-check" is needed, but
+    # might as well skip other work.
+    Mix.Tasks.Deps.Loadpaths.run([
+      "--no-deps-check",
+      "--no-elixir-version-check",
+      "--no-archives-check",
+      "--no-compile",
+      "--no-listeners"
+    ])
+  end
+end

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -12,9 +12,132 @@ defmodule NervesBootstrap do
 
   @impl Application
   def start(_type, _args) do
+    NervesBootstrap.UpdateChecker.check()
+
+    nerves_version = nerves_version()
+
+    # Check that the Nerves version is new enough to support this
+    # version of Nerves Bootstrap.
+    #
+    # This version of Nerves Bootstrap fails to install when the
+    # Elixir version is less than 1.15, so we're guaranteed that
+    # version. That forces a constraint on what Nerves versions
+    # can be used. Here's a truncated list for convenience.
+    #
+    # | Nerves version | Min Elixir version          | Max Elixir |
+    # |----------------|-----------------------------|------------|
+    # | 1.11.3         | 1.13                        | 1.18       |
+    # | 1.12.0         | 1.15.1                      | 1.19       |
+    # | 1.14.3         | 1.15.1 (inherited)          | 1.20       |
+
+    cond do
+      nerves_version == :no_dependency ->
+        report_error("""
+        The Nerves tooling is required, but :nerves is not a project dependency.
+
+        Check your mix.exs or add the following to your dependencies:
+
+            {:nerves, "~> 1.15", runtime: false}
+        """)
+
+      nerves_version == :need_deps_get ->
+        handle_undownloaded_nerves_package()
+
+      Version.match?(nerves_version, "< 1.11.3") ->
+        report_error("""
+        You are using :nerves #{nerves_version} which is incompatible with this version
+        of nerves_bootstrap and will result in compilation failures.
+
+        Please update to :nerves >= 1.11.3
+        """)
+
+      Version.match?(nerves_version, "< 2.0.0-dev") ->
+        start_nerves_v1(nerves_version)
+
+      true ->
+        report_error("""
+        You are using :nerves #{nerves_version} which is not supported by this version
+        of nerves_bootstrap.
+
+        Please update your version of nerves_bootstrap.
+        """)
+    end
+
+    {:ok, self()}
+  end
+
+  defp start_nerves_v1(nerves_version) do
+    workaround_v1_compile_partition_issue(nerves_version)
+    Aliases.inject_aliases_if_top(&Aliases.add_aliases_v1(Mix.target(), &1))
+  end
+
+  defp handle_undownloaded_nerves_package() do
+    req = nerves_mix_requirement_string()
+
+    if definitely_nerves_1_x?(req) do
+      # This is a workaround to not break the Nerves 1.x feature that
+      # mix deps.get can both get the Nerves tooling for the first time AND
+      # use it to download artifacts.
+      start_nerves_v1("<unknown>")
+    else
+      disallow_compilation("""
+      The :nerves package wasn't available at the beginning of compilation.
+
+      Please run `mix deps.get` to get the :nerves package. If you got this
+      error when running a list of mix tasks that included `deps.get`, run
+      `mix deps.get` by itself and then follow it with the rest of the tasks.
+      """)
+    end
+  end
+
+  defp report_error(msg) do
+    # Mix.raise only works from Mix tasks, so defer error to when a task is run
+    Aliases.inject_aliases_if_top(&Aliases.add_error_report_aliases(msg, &1))
+  end
+
+  defp disallow_compilation(msg) do
+    Aliases.inject_aliases_if_top(&Aliases.add_no_compilation_aliases(msg, &1))
+  end
+
+  defp nerves_version() do
+    path = Mix.Project.deps_paths()[:nerves]
+
+    cond do
+      path == nil ->
+        :no_dependency
+
+      File.dir?(path) ->
+        Mix.Project.in_project(:nerves, path, fn _ -> Mix.Project.config()[:version] end)
+
+      true ->
+        :need_deps_get
+    end
+  end
+
+  @doc false
+  @spec definitely_nerves_1_x?(String.t() | nil) :: boolean
+  def definitely_nerves_1_x?(req) when is_binary(req) do
+    # See the calling context. This isn't meant to be perfect.
+    case Version.parse_requirement(req) do
+      {:ok, r} -> Version.match?("1.999.999", r) and not Version.match?("2.999.999", r)
+      _ -> false
+    end
+  end
+
+  def definitely_nerves_1_x?(_req), do: false
+
+  defp nerves_mix_requirement_string() do
+    case Enum.find(Mix.Project.config()[:deps], &(elem(&1, 0) == :nerves)) do
+      {:nerves, req} -> req
+      {:nerves, req, _opts} -> req
+      _ -> nil
+    end
+  end
+
+  defp workaround_v1_compile_partition_issue(nerves_version) do
     if Version.match?(System.version(), ">= 1.19.0") and has_compile_partition_count?() do
       Mix.shell().error("""
-      Nerves does not support MIX_OS_DEPS_COMPILE_PARTITION_COUNT yet.
+      Nerves #{nerves_version} does not support MIX_OS_DEPS_COMPILE_PARTITION_COUNT.
 
       Disabling it for this build. To silence this warning, either unset
       MIX_OS_DEPS_COMPILE_PARTITION_COUNT or set it to 1 before you build.
@@ -25,9 +148,6 @@ defmodule NervesBootstrap do
 
       System.delete_env("MIX_OS_DEPS_COMPILE_PARTITION_COUNT")
     end
-
-    Aliases.inject_aliases_if_top(&Aliases.add_aliases(Mix.target(), &1))
-    {:ok, self()}
   end
 
   defp has_compile_partition_count?() do

--- a/lib/nerves_bootstrap.ex
+++ b/lib/nerves_bootstrap.ex
@@ -55,12 +55,7 @@ defmodule NervesBootstrap do
         start_nerves_v1(nerves_version)
 
       true ->
-        report_error("""
-        You are using :nerves #{nerves_version} which is not supported by this version
-        of nerves_bootstrap.
-
-        Please update your version of nerves_bootstrap.
-        """)
+        start_nerves_v2()
     end
 
     {:ok, self()}
@@ -69,6 +64,10 @@ defmodule NervesBootstrap do
   defp start_nerves_v1(nerves_version) do
     workaround_v1_compile_partition_issue(nerves_version)
     Aliases.inject_aliases_if_top(&Aliases.add_aliases_v1(Mix.target(), &1))
+  end
+
+  defp start_nerves_v2() do
+    Aliases.inject_aliases_if_top(&Aliases.add_aliases/1)
   end
 
   defp handle_undownloaded_nerves_package() do

--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -21,6 +21,14 @@ defmodule NervesBootstrap.Aliases do
     end
   end
 
+  @spec add_aliases(keyword()) :: keyword()
+  def add_aliases(aliases) do
+    aliases
+    |> prepend("deps.loadpaths", "nerves_bootstrap.init")
+    |> prepend("compile", "nerves_bootstrap.init")
+    |> replace("run", &NervesBootstrap.Aliases.run/1)
+  end
+
   @spec add_error_report_aliases(String.t(), keyword()) :: keyword()
   def add_error_report_aliases(msg, aliases) do
     raise_fun = raise_alias(msg)

--- a/lib/nerves_bootstrap/aliases.ex
+++ b/lib/nerves_bootstrap/aliases.ex
@@ -21,26 +21,52 @@ defmodule NervesBootstrap.Aliases do
     end
   end
 
-  @spec add_aliases(atom(), keyword()) :: keyword()
-  def add_aliases(:host, aliases) do
+  @spec add_error_report_aliases(String.t(), keyword()) :: keyword()
+  def add_error_report_aliases(msg, aliases) do
+    raise_fun = raise_alias(msg)
+
     aliases
-    |> append("deps.get", "nerves.bootstrap")
-    |> append("deps.get", "nerves.deps.get")
-    |> prepend("deps.precompile", "nerves.bootstrap")
-    |> replace("deps.update", &NervesBootstrap.Aliases.deps_update/1)
+    |> replace("deps.get", raise_fun)
+    |> replace("deps.loadpaths", raise_fun)
+    |> replace("deps.update", raise_fun)
+    |> replace("loadpaths", raise_fun)
+    |> replace("compile", raise_fun)
   end
 
-  def add_aliases(_target, aliases) do
+  @spec add_no_compilation_aliases(String.t(), keyword()) :: keyword()
+  def add_no_compilation_aliases(msg, aliases) do
+    raise_fun = raise_alias(msg)
+
+    aliases
+    |> replace("deps.compile", raise_fun)
+    |> replace("compile", raise_fun)
+  end
+
+  @spec raise_alias(String.t()) :: (term() -> no_return())
+  defp raise_alias(msg) do
+    fn _ -> Mix.raise(msg) end
+  end
+
+  @spec add_aliases_v1(atom(), keyword()) :: keyword()
+  def add_aliases_v1(:host, aliases) do
     aliases
     |> append("deps.get", "nerves.bootstrap")
     |> append("deps.get", "nerves.deps.get")
     |> prepend("deps.precompile", "nerves.bootstrap")
-    |> replace("deps.update", &NervesBootstrap.Aliases.deps_update/1)
+    |> replace_at_end("deps.update", &NervesBootstrap.Aliases.deps_update/1)
+  end
+
+  def add_aliases_v1(_target, aliases) do
+    aliases
+    |> append("deps.get", "nerves.bootstrap")
+    |> append("deps.get", "nerves.deps.get")
+    |> prepend("deps.precompile", "nerves.bootstrap")
+    |> replace_at_end("deps.update", &NervesBootstrap.Aliases.deps_update/1)
     |> prepend("deps.loadpaths", "nerves.loadpaths")
     |> prepend("deps.loadpaths", "nerves.bootstrap")
     |> prepend("deps.compile", "nerves.loadpaths")
     |> prepend("deps.compile", "nerves.bootstrap")
-    |> replace("run", &NervesBootstrap.Aliases.run/1)
+    |> replace_at_end("run", &NervesBootstrap.Aliases.run/1)
   end
 
   @spec run([String.t()]) :: :ok
@@ -57,6 +83,7 @@ defmodule NervesBootstrap.Aliases do
     end
   end
 
+  # v1 only
   @spec deps_update([String.t()]) :: :ok
   def deps_update(args) do
     Mix.Tasks.Deps.Update.run(args)
@@ -74,10 +101,20 @@ defmodule NervesBootstrap.Aliases do
     Keyword.update(aliases, key, [na, a], &[na | drop(&1, na)])
   end
 
+  defp replace_at_end(aliases, a, fun) do
+    # This maintains v1 semantics for replace()
+    key = String.to_atom(a)
+    Keyword.update(aliases, key, [fun], &(drop(drop(&1, a), fun) ++ [fun]))
+  end
+
   defp replace(aliases, a, fun) do
     key = String.to_atom(a)
-    Keyword.update(aliases, key, [fun], &(drop(&1, fun) ++ [fun]))
+    Keyword.update(aliases, key, [fun], &do_replace(&1, a, fun))
   end
+
+  defp do_replace(values, from, to), do: Enum.map(values, &maybe_replace(&1, from, to))
+  defp maybe_replace(value, from, to) when value == from, do: to
+  defp maybe_replace(value, _from, _to), do: value
 
   defp drop(aliases, a) do
     Enum.reject(aliases, &(&1 === a))

--- a/test/mix/tasks/nerves.bootstrap_test.exs
+++ b/test/mix/tasks/nerves.bootstrap_test.exs
@@ -6,6 +6,14 @@ defmodule Mix.Tasks.Nerves.BootstrapTest do
   use ExUnit.Case
 
   test "raises when :nerves is not a dependency" do
-    assert_raise Mix.Error, fn -> Mix.Tasks.Nerves.Bootstrap.run([]) end
+    NervesBootstrap.start(:normal, [])
+
+    # Check that error alias is registered with the expected error message
+    aliases = Mix.Project.config()[:aliases]
+    [raise_fn | _] = Keyword.get(aliases, :"deps.loadpaths")
+
+    assert_raise Mix.Error, ~r/:nerves is not a project dependency/, fn ->
+      raise_fn.([])
+    end
   end
 end

--- a/test/nerves_bootstrap/aliases_test.exs
+++ b/test/nerves_bootstrap/aliases_test.exs
@@ -8,111 +8,182 @@ defmodule NervesBootstrap.AliasTest do
 
   alias NervesBootstrap.Aliases
 
-  test "target aliases are injected properly" do
-    deps_loadpaths = ["nerves.bootstrap", "nerves.loadpaths", "deps.loadpaths"]
-    deps_get = ["deps.get", "nerves.bootstrap", "nerves.deps.get"]
-    deps_update = [&Aliases.deps_update/1]
-    deps_precompile = ["nerves.bootstrap", "deps.precompile"]
-    deps_compile = ["nerves.bootstrap", "nerves.loadpaths", "deps.compile"]
-    run = [&Aliases.run/1]
+  describe "add_aliases/1" do
+    test "aliases are injected properly" do
+      deps_loadpaths = ["nerves_bootstrap.init", "deps.loadpaths"]
+      compile = ["nerves_bootstrap.init", "compile"]
 
-    aliases = Aliases.add_aliases_v1(:target, [])
-    assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
-    assert Keyword.get(aliases, :"deps.get") == deps_get
-    assert Keyword.get(aliases, :"deps.update") == deps_update
-    assert Keyword.get(aliases, :"deps.precompile") == deps_precompile
-    assert Keyword.get(aliases, :"deps.compile") == deps_compile
-    assert Keyword.get(aliases, :run) == run
-    assert length(aliases) == 6
+      aliases = Aliases.add_aliases([])
+      assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
+      assert Keyword.get(aliases, :compile) == compile
+      assert Keyword.get(aliases, :run) == [&NervesBootstrap.Aliases.run/1]
+    end
+
+    test "custom aliases are maintained" do
+      custom_aliases = [
+        "deps.loadpaths": ["custom", "deps.loadpaths"],
+        compile: ["custom", "compile"],
+        "deps.update": ["custom"],
+        custom: ["custom"]
+      ]
+
+      aliases = Aliases.add_aliases(custom_aliases)
+
+      assert Keyword.get(aliases, :"deps.loadpaths") == [
+               "nerves_bootstrap.init",
+               "custom",
+               "deps.loadpaths"
+             ]
+
+      assert Keyword.get(aliases, :compile) == [
+               "nerves_bootstrap.init",
+               "custom",
+               "compile"
+             ]
+
+      assert Keyword.get(aliases, :run) == [&NervesBootstrap.Aliases.run/1]
+      assert Keyword.get(aliases, :custom) == ["custom"]
+    end
+
+    test "aliases are dropped if they already exist" do
+      deps_loadpaths = ["nerves_bootstrap.init", "deps.loadpaths"]
+      compile = ["nerves_bootstrap.init", "compile"]
+
+      nerves_aliases = [
+        "deps.loadpaths": deps_loadpaths,
+        compile: compile
+      ]
+
+      aliases = Aliases.add_aliases(nerves_aliases)
+      assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
+      assert Keyword.get(aliases, :compile) == compile
+    end
+
+    test "replace skipped if user has already replaced" do
+      # See v1 version of this test for how it used to append the Nerves tooling's run
+      # replacement even when the user's mix.exs overrode the default.
+      custom_aliases = [run: ["custom"]]
+      aliases = Aliases.add_aliases(custom_aliases)
+      assert Keyword.get(aliases, :run) == ["custom"]
+    end
   end
 
-  test "host aliases are injected properly" do
-    deps_get = ["deps.get", "nerves.bootstrap", "nerves.deps.get"]
-    deps_update = [&Aliases.deps_update/1]
-    deps_precompile = ["nerves.bootstrap", "deps.precompile"]
+  describe "add_aliases_v1/1" do
+    test "target aliases are injected properly" do
+      deps_loadpaths = ["nerves.bootstrap", "nerves.loadpaths", "deps.loadpaths"]
+      deps_get = ["deps.get", "nerves.bootstrap", "nerves.deps.get"]
+      deps_update = [&Aliases.deps_update/1]
+      deps_precompile = ["nerves.bootstrap", "deps.precompile"]
+      deps_compile = ["nerves.bootstrap", "nerves.loadpaths", "deps.compile"]
+      run = [&Aliases.run/1]
 
-    aliases = Aliases.add_aliases_v1(:host, [])
+      aliases = Aliases.add_aliases_v1(:target, [])
+      assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
+      assert Keyword.get(aliases, :"deps.get") == deps_get
+      assert Keyword.get(aliases, :"deps.update") == deps_update
+      assert Keyword.get(aliases, :"deps.precompile") == deps_precompile
+      assert Keyword.get(aliases, :"deps.compile") == deps_compile
+      assert Keyword.get(aliases, :run) == run
+      assert length(aliases) == 6
+    end
 
-    assert Keyword.get(aliases, :"deps.get") == deps_get
-    assert Keyword.get(aliases, :"deps.update") == deps_update
-    assert Keyword.get(aliases, :"deps.precompile") == deps_precompile
-    assert length(aliases) == 3
+    test "host aliases are injected properly" do
+      deps_get = ["deps.get", "nerves.bootstrap", "nerves.deps.get"]
+      deps_update = [&Aliases.deps_update/1]
+      deps_precompile = ["nerves.bootstrap", "deps.precompile"]
+
+      aliases = Aliases.add_aliases_v1(:host, [])
+
+      assert Keyword.get(aliases, :"deps.get") == deps_get
+      assert Keyword.get(aliases, :"deps.update") == deps_update
+      assert Keyword.get(aliases, :"deps.precompile") == deps_precompile
+      assert length(aliases) == 3
+    end
+
+    test "custom aliases are maintained" do
+      custom_aliases = [
+        "deps.loadpaths": ["custom", "nerves.bootstrap", "deps.loadpaths"],
+        "deps.get": ["deps.get", "nerves.bootstrap", "custom"],
+        "deps.update": ["custom"],
+        custom: ["custom"]
+      ]
+
+      aliases = Aliases.add_aliases_v1(:target, custom_aliases)
+
+      assert Keyword.get(aliases, :"deps.loadpaths") == [
+               "nerves.bootstrap",
+               "nerves.loadpaths",
+               "custom",
+               "deps.loadpaths"
+             ]
+
+      assert Keyword.get(aliases, :"deps.get") == [
+               "deps.get",
+               "custom",
+               "nerves.bootstrap",
+               "nerves.deps.get"
+             ]
+
+      assert Keyword.get(aliases, :"deps.update") == [
+               "custom",
+               &Aliases.deps_update/1
+             ]
+
+      assert Keyword.get(aliases, :custom) == ["custom"]
+    end
+
+    test "aliases are dropped if they already exist" do
+      deps_loadpaths = ["nerves.bootstrap", "nerves.loadpaths", "deps.loadpaths"]
+      deps_get = ["deps.get", "nerves.bootstrap", "nerves.deps.get"]
+      deps_update = [&Aliases.deps_update/1]
+
+      nerves_aliases = [
+        "deps.loadpaths": deps_loadpaths
+      ]
+
+      aliases = Aliases.add_aliases_v1(:host, nerves_aliases)
+      assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
+      assert Keyword.get(aliases, :"deps.get") == deps_get
+      assert Keyword.get(aliases, :"deps.update") == deps_update
+    end
+
+    test "v1 replace appends alias even if nothing to replace" do
+      # This preserves v1 semantics
+      custom_aliases = [run: ["custom"]]
+      aliases = Aliases.add_aliases_v1(:target, custom_aliases)
+      assert Keyword.get(aliases, :run) == ["custom", &NervesBootstrap.Aliases.run/1]
+    end
   end
 
-  test "custom aliases are maintained" do
-    custom_aliases = [
-      "deps.loadpaths": ["custom", "nerves.bootstrap", "deps.loadpaths"],
-      "deps.get": ["deps.get", "nerves.bootstrap", "custom"],
-      "deps.update": ["custom"],
-      custom: ["custom"]
-    ]
+  describe "run/1" do
+    test "mix run delegates to Mix.Tasks.Run on host target" do
+      # Mix.target() defaults to :host in tests, so this exercises the host branch
+      Aliases.run(["-e", "nil"])
+    end
 
-    aliases = Aliases.add_aliases_v1(:target, custom_aliases)
+    test "mix run prints an error on non-host targets" do
+      previous_target = Mix.State.get(:target)
+      previous_mix_target_env = System.get_env("MIX_TARGET")
 
-    assert Keyword.get(aliases, :"deps.loadpaths") == [
-             "nerves.bootstrap",
-             "nerves.loadpaths",
-             "custom",
-             "deps.loadpaths"
-           ]
+      on_exit(fn ->
+        Mix.State.put(:target, previous_target)
 
-    assert Keyword.get(aliases, :"deps.get") == [
-             "deps.get",
-             "custom",
-             "nerves.bootstrap",
-             "nerves.deps.get"
-           ]
+        case previous_mix_target_env do
+          nil -> System.delete_env("MIX_TARGET")
+          value -> System.put_env("MIX_TARGET", value)
+        end
+      end)
 
-    assert Keyword.get(aliases, :"deps.update") == [
-             "custom",
-             &Aliases.deps_update/1
-           ]
+      System.put_env("MIX_TARGET", "rpi3")
+      Mix.State.put(:target, :rpi3)
 
-    assert Keyword.get(aliases, :custom) == ["custom"]
-  end
+      Aliases.run([])
 
-  test "aliases are dropped if they already exist" do
-    deps_loadpaths = ["nerves.bootstrap", "nerves.loadpaths", "deps.loadpaths"]
-    deps_get = ["deps.get", "nerves.bootstrap", "nerves.deps.get"]
-    deps_update = [&Aliases.deps_update/1]
+      assert_receive {:mix_shell, :error, message}
 
-    nerves_aliases = [
-      "deps.loadpaths": deps_loadpaths
-    ]
-
-    aliases = Aliases.add_aliases_v1(:host, nerves_aliases)
-    assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
-    assert Keyword.get(aliases, :"deps.get") == deps_get
-    assert Keyword.get(aliases, :"deps.update") == deps_update
-  end
-
-  test "mix run delegates to Mix.Tasks.Run on host target" do
-    # Mix.target() defaults to :host in tests, so this exercises the host branch
-    Aliases.run(["-e", "nil"])
-  end
-
-  test "mix run prints an error on non-host targets" do
-    previous_target = Mix.State.get(:target)
-    previous_mix_target_env = System.get_env("MIX_TARGET")
-
-    on_exit(fn ->
-      Mix.State.put(:target, previous_target)
-
-      case previous_mix_target_env do
-        nil -> System.delete_env("MIX_TARGET")
-        value -> System.put_env("MIX_TARGET", value)
-      end
-    end)
-
-    System.put_env("MIX_TARGET", "rpi3")
-    Mix.State.put(:target, :rpi3)
-
-    Aliases.run([])
-
-    assert_receive {:mix_shell, :error, message}
-
-    text = IO.iodata_to_binary(message)
-    assert text =~ "You are trying to run code compiled for the 'rpi3' target"
-    assert text =~ "Please unset MIX_TARGET to run in host mode."
+      text = IO.iodata_to_binary(message)
+      assert text =~ "You are trying to run code compiled for the 'rpi3' target"
+      assert text =~ "Please unset MIX_TARGET to run in host mode."
+    end
   end
 end

--- a/test/nerves_bootstrap/aliases_test.exs
+++ b/test/nerves_bootstrap/aliases_test.exs
@@ -16,7 +16,7 @@ defmodule NervesBootstrap.AliasTest do
     deps_compile = ["nerves.bootstrap", "nerves.loadpaths", "deps.compile"]
     run = [&Aliases.run/1]
 
-    aliases = Aliases.add_aliases(:target, [])
+    aliases = Aliases.add_aliases_v1(:target, [])
     assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
     assert Keyword.get(aliases, :"deps.get") == deps_get
     assert Keyword.get(aliases, :"deps.update") == deps_update
@@ -31,7 +31,7 @@ defmodule NervesBootstrap.AliasTest do
     deps_update = [&Aliases.deps_update/1]
     deps_precompile = ["nerves.bootstrap", "deps.precompile"]
 
-    aliases = Aliases.add_aliases(:host, [])
+    aliases = Aliases.add_aliases_v1(:host, [])
 
     assert Keyword.get(aliases, :"deps.get") == deps_get
     assert Keyword.get(aliases, :"deps.update") == deps_update
@@ -47,7 +47,7 @@ defmodule NervesBootstrap.AliasTest do
       custom: ["custom"]
     ]
 
-    aliases = Aliases.add_aliases(:target, custom_aliases)
+    aliases = Aliases.add_aliases_v1(:target, custom_aliases)
 
     assert Keyword.get(aliases, :"deps.loadpaths") == [
              "nerves.bootstrap",
@@ -80,7 +80,7 @@ defmodule NervesBootstrap.AliasTest do
       "deps.loadpaths": deps_loadpaths
     ]
 
-    aliases = Aliases.add_aliases(:host, nerves_aliases)
+    aliases = Aliases.add_aliases_v1(:host, nerves_aliases)
     assert Keyword.get(aliases, :"deps.loadpaths") == deps_loadpaths
     assert Keyword.get(aliases, :"deps.get") == deps_get
     assert Keyword.get(aliases, :"deps.update") == deps_update

--- a/test/nerves_bootstrap_test.exs
+++ b/test/nerves_bootstrap_test.exs
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Frank Hunleth
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesBootstrapTest do
+  use ExUnit.Case
+
+  test "definitely_nerves_1_x?/1" do
+    # Common cases in the wild
+    assert NervesBootstrap.definitely_nerves_1_x?("~> 1.8")
+    assert NervesBootstrap.definitely_nerves_1_x?("~> 1.11")
+    assert NervesBootstrap.definitely_nerves_1_x?("~> 1.11.3 or ~> 1.12")
+
+    # Not yet common in the wild
+    refute NervesBootstrap.definitely_nerves_1_x?("~> 2.0.0-dev")
+    refute NervesBootstrap.definitely_nerves_1_x?("~> 2.0")
+    refute NervesBootstrap.definitely_nerves_1_x?("~> 1.11 or ~> 2.0")
+
+    # Bad versions that return false to fail through to mix
+    refute NervesBootstrap.definitely_nerves_1_x?(nil)
+    refute NervesBootstrap.definitely_nerves_1_x?("oops")
+  end
+end


### PR DESCRIPTION
This is a draft pull request since there's not a Nerves 2 dev release yet. When there is, it will be possible to add the integration tests here to properly verify that the new code is working. 

This branch is convenient since both Nerves 1 and 2 will work with it. 

Note that the new project generator generates v1 projects. My intention is to not bump the new project generator until v2 is officially released.